### PR TITLE
Middleware creates hypervisor with known key

### DIFF
--- a/packages/app-account/public/index.html
+++ b/packages/app-account/public/index.html
@@ -17,7 +17,6 @@
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
-
       Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.

--- a/packages/interbit-middleware/src/interbitGlobal.js
+++ b/packages/interbit-middleware/src/interbitGlobal.js
@@ -33,7 +33,7 @@ const createContext = async () => {
   }
 
   console.log(`${LOG_PREFIX}: Starting interbit hypervisor`)
-  const hypervisor = await interbit.createHypervisor(keyPair)
+  const hypervisor = await interbit.createHypervisor({ keyPair })
 
   console.log(`${LOG_PREFIX}: Creating interbit client`)
   const cli = await interbit.createCli(hypervisor)

--- a/packages/interbit-test/test/genesisBlock.js
+++ b/packages/interbit-test/test/genesisBlock.js
@@ -1,0 +1,47 @@
+module.exports = {
+  content: {
+    previousHash: 'genesis',
+    stateHash:
+      '4201a2caa39626873731480cb93fdf27335e2fc4cf49511566765fd3dc5ba564',
+    actions: [],
+    errors: {},
+    redispatches: {},
+    height: 0,
+    timestamp: 1523660335422,
+    seed: 0.7908571874018981,
+    configChanged: true,
+    timeToCreateBlock: 0,
+    state: {
+      interbit: {
+        config: {
+          consensus: 'PoA',
+          providing: [],
+          consuming: [],
+          acl: {
+            actionPermissions: {
+              '*': ['root']
+            },
+            roles: {
+              root: [
+                '-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: OpenPGP.js v2.5.2\nComment: http://openpgpjs.org\n\nxk0EWN0/BQEB/1R8H/WSzYR97uXnm7XpynjIlo6WK+qTuzQr3Gtb5Q6jV/HO\n7Yl9BjCbpbA4OXdT/1CImJ53zvJBZAcNUrW9Wc8AEQEAAc0RQlRMIDxpbmZv\nQGJ0bC5jbz7CdQQQAQgAKQUCWN0/BQYLCQcIAwIJEEq0xDiCCwdsBBUICgID\nFgIBAhkBAhsDAh4BAAAO7AH9E9DuIPDCDGAmREffEDtbP4JOjzIl45VqoH5M\nPThXGWNuYVb9Nn7GD8iCqBHRFhhhaXMVuDr7e68qd/I+CvKX0c5NBFjdPwUB\nAf9soNyJh4Sv3zuh2kG0byjTtGMFwTZ+QmnEYtlm/q4F59J5gmlv52OTY+bH\na2HLGmzuTFxwr1jkSOA8CfYp85/nABEBAAHCXwQYAQgAEwUCWN0/BQkQSrTE\nOIILB2wCGwwAAHHIAf9Ohcudsms6N9d6uGRXfLy/Ltu8uR37fmG242zjCLg4\nfT2QuwcZCN8hKMUuD2kvbh502ov9Kdr8cE81Mxs+pkPC\n=yjbz\n-----END PGP PUBLIC KEY BLOCK-----'
+              ]
+            }
+          },
+          blockMaster:
+            '-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: OpenPGP.js v2.5.2\nComment: http://openpgpjs.org\n\nxk0EWN0/BQEB/1R8H/WSzYR97uXnm7XpynjIlo6WK+qTuzQr3Gtb5Q6jV/HO\n7Yl9BjCbpbA4OXdT/1CImJ53zvJBZAcNUrW9Wc8AEQEAAc0RQlRMIDxpbmZv\nQGJ0bC5jbz7CdQQQAQgAKQUCWN0/BQYLCQcIAwIJEEq0xDiCCwdsBBUICgID\nFgIBAhkBAhsDAh4BAAAO7AH9E9DuIPDCDGAmREffEDtbP4JOjzIl45VqoH5M\nPThXGWNuYVb9Nn7GD8iCqBHRFhhhaXMVuDr7e68qd/I+CvKX0c5NBFjdPwUB\nAf9soNyJh4Sv3zuh2kG0byjTtGMFwTZ+QmnEYtlm/q4F59J5gmlv52OTY+bH\na2HLGmzuTFxwr1jkSOA8CfYp85/nABEBAAHCXwQYAQgAEwUCWN0/BQkQSrTE\nOIILB2wCGwwAAHHIAf9Ohcudsms6N9d6uGRXfLy/Ltu8uR37fmG242zjCLg4\nfT2QuwcZCN8hKMUuD2kvbh502ov9Kdr8cE81Mxs+pkPC\n=yjbz\n-----END PGP PUBLIC KEY BLOCK-----',
+          covenantHash:
+            '4aec30b1eec215d0ae37f6c8798957f0be0e3e5f1a0eaab99de1f2124cce65e2'
+        },
+        configChanges: {}
+      }
+    }
+  },
+  contentHash:
+    '6ff3827033392bcea85fee3bb4957cdb38483a54d70a2e8aa3f7a289fbeb9614',
+  signatures: {
+    GENESIS: 'GENESIS'
+  },
+  signaturesHash:
+    '5802612e380de8f088c9c9ab28412e853d75d86eed65d8415bca52daac7681ce',
+  blockHash: 'ab197aa8077b8bebf50d271917ae395506b3f881ccfecadb34477939fd2d7989'
+}

--- a/packages/interbit-test/test/genesisBlocks.test.js
+++ b/packages/interbit-test/test/genesisBlocks.test.js
@@ -26,7 +26,6 @@ const {
   createGenesisBlock,
   createDefaultSponsoredChainConfig
 } = require('interbit-core')
-const interbit = require('interbit-core')
 
 describe('chain sponsorship', () => {
   const blockMasterPublicKey = 'pubKey1'
@@ -92,67 +91,4 @@ describe('chain sponsorship', () => {
 
     assert.deepEqual(genesisBlock.content.state.interbit.config, expectedConfig)
   })
-
-  it('will boot a chain that has the chain ID specified in the generated genesis block', async () => {
-    const genesisBlock = {
-      content: {
-        previousHash: 'genesis',
-        stateHash:
-          '4201a2caa39626873731480cb93fdf27335e2fc4cf49511566765fd3dc5ba564',
-        actions: [],
-        errors: {},
-        redispatches: {},
-        height: 0,
-        timestamp: 1523660335422,
-        seed: 0.7908571874018981,
-        configChanged: true,
-        timeToCreateBlock: 0,
-        state: {
-          interbit: {
-            config: {
-              consensus: 'PoA',
-              providing: [],
-              consuming: [],
-              acl: {
-                actionPermissions: {
-                  '*': ['root']
-                },
-                roles: {
-                  root: [
-                    '-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: OpenPGP.js v2.5.2\nComment: http://openpgpjs.org\n\nxk0EWN0/BQEB/1R8H/WSzYR97uXnm7XpynjIlo6WK+qTuzQr3Gtb5Q6jV/HO\n7Yl9BjCbpbA4OXdT/1CImJ53zvJBZAcNUrW9Wc8AEQEAAc0RQlRMIDxpbmZv\nQGJ0bC5jbz7CdQQQAQgAKQUCWN0/BQYLCQcIAwIJEEq0xDiCCwdsBBUICgID\nFgIBAhkBAhsDAh4BAAAO7AH9E9DuIPDCDGAmREffEDtbP4JOjzIl45VqoH5M\nPThXGWNuYVb9Nn7GD8iCqBHRFhhhaXMVuDr7e68qd/I+CvKX0c5NBFjdPwUB\nAf9soNyJh4Sv3zuh2kG0byjTtGMFwTZ+QmnEYtlm/q4F59J5gmlv52OTY+bH\na2HLGmzuTFxwr1jkSOA8CfYp85/nABEBAAHCXwQYAQgAEwUCWN0/BQkQSrTE\nOIILB2wCGwwAAHHIAf9Ohcudsms6N9d6uGRXfLy/Ltu8uR37fmG242zjCLg4\nfT2QuwcZCN8hKMUuD2kvbh502ov9Kdr8cE81Mxs+pkPC\n=yjbz\n-----END PGP PUBLIC KEY BLOCK-----'
-                  ]
-                }
-              },
-              blockMaster:
-                '-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: OpenPGP.js v2.5.2\nComment: http://openpgpjs.org\n\nxk0EWN0/BQEB/1R8H/WSzYR97uXnm7XpynjIlo6WK+qTuzQr3Gtb5Q6jV/HO\n7Yl9BjCbpbA4OXdT/1CImJ53zvJBZAcNUrW9Wc8AEQEAAc0RQlRMIDxpbmZv\nQGJ0bC5jbz7CdQQQAQgAKQUCWN0/BQYLCQcIAwIJEEq0xDiCCwdsBBUICgID\nFgIBAhkBAhsDAh4BAAAO7AH9E9DuIPDCDGAmREffEDtbP4JOjzIl45VqoH5M\nPThXGWNuYVb9Nn7GD8iCqBHRFhhhaXMVuDr7e68qd/I+CvKX0c5NBFjdPwUB\nAf9soNyJh4Sv3zuh2kG0byjTtGMFwTZ+QmnEYtlm/q4F59J5gmlv52OTY+bH\na2HLGmzuTFxwr1jkSOA8CfYp85/nABEBAAHCXwQYAQgAEwUCWN0/BQkQSrTE\nOIILB2wCGwwAAHHIAf9Ohcudsms6N9d6uGRXfLy/Ltu8uR37fmG242zjCLg4\nfT2QuwcZCN8hKMUuD2kvbh502ov9Kdr8cE81Mxs+pkPC\n=yjbz\n-----END PGP PUBLIC KEY BLOCK-----',
-              covenantHash:
-                '4aec30b1eec215d0ae37f6c8798957f0be0e3e5f1a0eaab99de1f2124cce65e2'
-            },
-            configChanges: {}
-          }
-        }
-      },
-      contentHash:
-        '6ff3827033392bcea85fee3bb4957cdb38483a54d70a2e8aa3f7a289fbeb9614',
-      signatures: {
-        GENESIS: 'GENESIS'
-      },
-      signaturesHash:
-        '5802612e380de8f088c9c9ab28412e853d75d86eed65d8415bca52daac7681ce',
-      blockHash:
-        'ab197aa8077b8bebf50d271917ae395506b3f881ccfecadb34477939fd2d7989'
-    }
-
-    const hypervisor = await interbit.createHypervisor()
-
-    hypervisor.startHyperBlocker()
-    try {
-      const cli = await interbit.createCli(hypervisor)
-      const chainId = await cli.startChain({ genesisBlock })
-
-      assert.equal(chainId, genesisBlock.blockHash)
-    } finally {
-      hypervisor.stopHyperBlocker()
-    }
-  }).timeout(5000)
 })

--- a/packages/interbit-test/test/interbit.test.js
+++ b/packages/interbit-test/test/interbit.test.js
@@ -1,6 +1,7 @@
 // © 2018 BTL GROUP LTD -  This package is licensed under the MIT license https://opensource.org/licenses/MIT
 const assert = require('assert')
 const interbit = require('interbit-core')
+const genesisBlock = require('./genesisBlock')
 
 describe('interbit', () => {
   it('is imported', () => {
@@ -30,49 +31,66 @@ describe('interbit', () => {
   })
 
   describe('hypervisor', () => {
-    it('has expected API', async () => {
-      const hypervisor = await interbit.createHypervisor()
-      console.log('hypervisor: ', hypervisor)
+    let hypervisor
+    let keyPair
 
-      try {
-        assert.ok(hypervisor.dispatch)
-        assert.equal(typeof hypervisor.dispatch, 'function')
+    // regular function is required for before to honour timeout
+    // eslint-disable-next-line prefer-arrow-callback
+    before(async function() {
+      this.timeout(5000)
+      keyPair = await interbit.generateKeyPair()
+      hypervisor = await interbit.createHypervisor({ keyPair })
+    })
 
-        assert.ok(hypervisor.getState)
-        assert.equal(typeof hypervisor.getState, 'function')
-
-        assert.ok(hypervisor.subscribe)
-        assert.equal(typeof hypervisor.subscribe, 'function')
-
-        assert.ok(hypervisor.startHyperBlocker)
-        assert.equal(typeof hypervisor.startHyperBlocker, 'function')
-
-        assert.ok(hypervisor.stopHyperBlocker)
-        assert.equal(typeof hypervisor.stopHyperBlocker, 'function')
-
-        assert.ok(hypervisor.getCurrentBlock)
-        assert.equal(typeof hypervisor.getCurrentBlock, 'function')
-
-        assert.ok(hypervisor.setHeavyBlockInterval)
-        assert.equal(typeof hypervisor.setHeavyBlockInterval, 'function')
-
-        assert.ok(hypervisor.waitForState)
-        assert.equal(typeof hypervisor.waitForState, 'function')
-
-        assert.ok(hypervisor.chainId)
-        assert.equal(typeof hypervisor.chainId, 'string')
-      } finally {
+    after(async () => {
+      if (hypervisor) {
         hypervisor.stopHyperBlocker()
       }
     })
-  })
 
-  describe('cli', () => {
-    it('has expected API', async () => {
-      const hypervisor = await interbit.createHypervisor()
+    it('has expected API', () => {
+      console.log('hypervisor: ', hypervisor)
 
-      try {
-        const cli = await interbit.createCli(hypervisor)
+      assert.ok(hypervisor.dispatch)
+      assert.equal(typeof hypervisor.dispatch, 'function')
+
+      assert.ok(hypervisor.getState)
+      assert.equal(typeof hypervisor.getState, 'function')
+
+      assert.ok(hypervisor.subscribe)
+      assert.equal(typeof hypervisor.subscribe, 'function')
+
+      assert.ok(hypervisor.startHyperBlocker)
+      assert.equal(typeof hypervisor.startHyperBlocker, 'function')
+
+      assert.ok(hypervisor.stopHyperBlocker)
+      assert.equal(typeof hypervisor.stopHyperBlocker, 'function')
+
+      assert.ok(hypervisor.getCurrentBlock)
+      assert.equal(typeof hypervisor.getCurrentBlock, 'function')
+
+      assert.ok(hypervisor.setHeavyBlockInterval)
+      assert.equal(typeof hypervisor.setHeavyBlockInterval, 'function')
+
+      assert.ok(hypervisor.waitForState)
+      assert.equal(typeof hypervisor.waitForState, 'function')
+
+      assert.ok(hypervisor.chainId)
+      assert.equal(typeof hypervisor.chainId, 'string')
+    })
+
+    it('boots with the supplied key', () => {
+      assert.deepEqual(hypervisor.keyPair, keyPair)
+    })
+
+    describe('cli', () => {
+      let cli
+
+      before(async () => {
+        cli = await interbit.createCli(hypervisor)
+      })
+
+      it('has expected API', async () => {
         console.log('cli: ', cli)
 
         assert.ok(cli.connect)
@@ -128,39 +146,35 @@ describe('interbit', () => {
 
         assert.ok(cli.stopServer)
         assert.equal(typeof cli.stopServer, 'function')
-      } finally {
-        hypervisor.stopHyperBlocker()
-      }
+      })
+
+      it('will boot a chain that has the chain ID specified in the generated genesis block', async () => {
+        const chainId = await cli.startChain({ genesisBlock })
+        assert.equal(chainId, genesisBlock.blockHash)
+      })
+
+      describe('chain', () => {
+        it('has expected API', async () => {
+          const chainId = await cli.createChain()
+          const chain = await cli.getChain(chainId)
+          console.log('chain: ', chain)
+
+          assert.ok(chain.dispatch)
+          assert.equal(typeof chain.dispatch, 'function')
+
+          assert.ok(chain.getState)
+          assert.equal(typeof chain.getState, 'function')
+
+          assert.ok(chain.getCurrentBlock)
+          assert.equal(typeof chain.getCurrentBlock, 'function')
+
+          assert.ok(chain.subscribe)
+          assert.equal(typeof chain.subscribe, 'function')
+
+          assert.ok(chain.getActionPoolLength)
+          assert.equal(typeof chain.getActionPoolLength, 'function')
+        })
+      })
     })
-  })
-
-  describe('chain', () => {
-    it('has expected API', async () => {
-      const hypervisor = await interbit.createHypervisor()
-
-      try {
-        const cli = await interbit.createCli(hypervisor)
-        const chainId = await cli.createChain()
-        const chain = await cli.getChain(chainId)
-        console.log('chain: ', chain)
-
-        assert.ok(chain.dispatch)
-        assert.equal(typeof chain.dispatch, 'function')
-
-        assert.ok(chain.getState)
-        assert.equal(typeof chain.getState, 'function')
-
-        assert.ok(chain.getCurrentBlock)
-        assert.equal(typeof chain.getCurrentBlock, 'function')
-
-        assert.ok(chain.subscribe)
-        assert.equal(typeof chain.subscribe, 'function')
-
-        assert.ok(chain.getActionPoolLength)
-        assert.equal(typeof chain.getActionPoolLength, 'function')
-      } finally {
-        hypervisor.stopHyperBlocker()
-      }
-    }).timeout(5000)
   })
 })


### PR DESCRIPTION
This fixes the 'unauthorized' errors when updating private changes created in the browser.

I have also changed the interbit-test suite so that it no longer creates and destroys hypervisors, which caused DB locking errors when the tests were run in parallel on the CI server.