### PR TITLE
getArg function returns undefined when no arg is specified following the options

### DIFF
--- a/packages/interbit-covenant-tools/package.json
+++ b/packages/interbit-covenant-tools/package.json
@@ -8,7 +8,7 @@
     "build": "webpack --env dev && webpack --env build",
     "build:watch": "webpack --env dev && webpack --env build --watch",
     "dev": "webpack --progress --colors --watch --env dev",
-    "test": "mocha tests/**/*.test.js"
+    "test": "mocha \"tests/**/*.test.js\""
   },
   "author": "BTL GROUP LTD",
   "license": "MIT",

--- a/packages/interbit-middleware/package.json
+++ b/packages/interbit-middleware/package.json
@@ -9,7 +9,7 @@
     "build": "webpack --env dev && webpack --env build",
     "build:watch": "webpack --env dev && webpack --env build --watch",
     "dev": "webpack --progress --colors --watch --env dev",
-    "test": "mocha tests/**/*.test.js"
+    "test": "mocha \"tests/**/*.test.js\""
   },
   "keywords": [
     "Interbit",

--- a/packages/interbit-utils/package.json
+++ b/packages/interbit-utils/package.json
@@ -4,7 +4,7 @@
   "description": "Requireable deployment utilities for interbit-cli",
   "main": "src/index.js",
   "scripts": {
-    "test": "mocha tests/**/*.test.js"
+    "test": "mocha \"tests/**/*.test.js\""
   },
   "author": "BTL GROUP LTD",
   "license": "MIT",

--- a/packages/interbit-utils/src/args/getArg.js
+++ b/packages/interbit-utils/src/args/getArg.js
@@ -1,6 +1,7 @@
 const getArg = (argv, argName) => {
   const argIndex = argv.indexOf(argName) + 1
-  const isArgAvailable = argIndex > 0 && argv.length > argIndex
+  const isArgAvailable =
+    argIndex > 0 && argv.length > argIndex && !argv[argIndex].startsWith('--')
 
   return isArgAvailable ? argv[argIndex] : undefined
 }

--- a/packages/interbit-utils/tests/getArg.test.js
+++ b/packages/interbit-utils/tests/getArg.test.js
@@ -2,6 +2,7 @@ const assert = require('assert')
 const { getArg, getArgs, isArg } = require('../src/args/getArg')
 
 const argName = '--argname'
+const anotherArgName = '--another-argname'
 const argValue = 'argvalue'
 
 describe('args', () => {
@@ -15,6 +16,12 @@ describe('args', () => {
 
     it('does not explode if arg was named but not supplied', () => {
       const argv = ['interbit', 'start', argName]
+      const arg = getArg(argv, argName)
+      assert.equal(arg, undefined)
+    })
+
+    it('returns undefined if argName is followed by another argName', () => {
+      const argv = ['interbit', 'start', argName, anotherArgName]
       const arg = getArg(argv, argName)
       assert.equal(arg, undefined)
     })
@@ -36,8 +43,25 @@ describe('args', () => {
       assert.deepEqual(args, expectedArgs)
     })
 
+    it('returns an empty array when argName is followed by another argName', () => {
+      const argv = ['interbit', 'start', argName, anotherArgName]
+      const expectedArgs = []
+
+      const args = getArgs(argv, argName)
+
+      assert.deepEqual(args, expectedArgs)
+    })
+
     it('returns an array of specified args if more than one was supplied', () => {
-      const argv = ['interbit', 'start', argName, argValue, argValue, argValue]
+      const argv = [
+        'interbit',
+        'start',
+        argName,
+        argValue,
+        argValue,
+        argValue,
+        anotherArgName
+      ]
       const expectedArgs = [argValue, argValue, argValue]
 
       const args = getArgs(argv, argName)


### PR DESCRIPTION
- getArg no longer returns another option if no value specified after --arg-option
- more tests for getArg/getArgs
- fix to mocha glob that was only running tests in subdirectory of tests/

fixes #54 