### PR TITLE
Move covenant hash to configurationChanges

### DIFF
--- a/packages/interbit-middleware/src/sagas/chains.js
+++ b/packages/interbit-middleware/src/sagas/chains.js
@@ -91,16 +91,15 @@ function* sponsorChain({
     )
   }
 
-  const genesisConfig = interbit
-    .createDefaultSponsoredChainConfig({
-      blockMaster,
-      myPublicKey: publicKey,
-      sponsorChainId
-    })
-    .merge({ covenantHash })
+  const genesisConfig = interbit.createDefaultSponsoredChainConfig({
+    blockMaster,
+    myPublicKey: publicKey,
+    sponsorChainId
+  })
 
   const genesisBlock = interbit.createGenesisBlock({
-    config: genesisConfig
+    config: genesisConfig,
+    configChanges: { covenantHash }
   })
 
   const chainId = genesisBlock.blockHash


### PR DESCRIPTION
This fixes issue #62 
Moving the covenantHash into configChanges defers applying the covenant until the chain is running.