### PR TITLE
Dedupe platform node peers

### DIFF
--- a/packages/platform-deploy/interbit.config.js
+++ b/packages/platform-deploy/interbit.config.js
@@ -1,3 +1,5 @@
+const _ = require('lodash')
+
 const accountConfig = require('../app-account/interbit.prod.config')
 const templateConfig = require('../template/interbit.prod.config')
 
@@ -28,6 +30,7 @@ const config = [accountConfig, templateConfig].reduce(
   init
 )
 
+config.peers = _.uniq(config.peers)
 console.log(config)
 
 module.exports = config

--- a/packages/platform-deploy/package.json
+++ b/packages/platform-deploy/package.json
@@ -18,7 +18,8 @@
   ],
   "dependencies": {
     "cross-env": "^5.1.4",
-    "interbit-cli": "0.4.14"
+    "interbit-cli": "0.4.14",
+    "lodash": "^4.17.5"
   },
   "author": "BTL GROUP LTD",
   "license": "MIT"


### PR DESCRIPTION
- Don't include duplicate peers when composing the platform node. This will prevent duplicate peers in index files on build.

closes #58