### PR TITLE
Allow heroku to pick port for web-auth-endpoint

### DIFF
--- a/packages/web-auth-endpoint/package.json
+++ b/packages/web-auth-endpoint/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "serve": "npm start",
-    "start": "cross-env COVENANT_DEV_MODE=true PORT=5002 DB_PATH=./db-interbit node src/index.js",
+    "start": "cross-env COVENANT_DEV_MODE=true DB_PATH=./db-interbit node src/index.js",
     "test": "echo \"Error: no test specified\""
   }
 }

--- a/packages/web-auth-endpoint/src/index.js
+++ b/packages/web-auth-endpoint/src/index.js
@@ -6,7 +6,7 @@ const {
 } = require('app-account')
 const interbitNode = require('./interbitNode')
 
-const port = process.env.PORT || 9999
+const port = process.env.PORT || 5002
 
 // @dave: I am not really sure where this request comes from so please adjust the whitelist as necessary
 const whitelist = [`localhost:${port}`, 'github.com']


### PR DESCRIPTION
Allow heroku to set port and use 5002 as default in server for web-auth-endpoint

