### PR TITLE
Ensures es5 under the `interbit` folder

### DIFF
--- a/packages/template/src/interbit/.eslintrc
+++ b/packages/template/src/interbit/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "env": { "es6": false },
+  "parserOptions": {
+    "ecmaVersion": 5
+  }
+}

--- a/packages/template/src/interbit/private/actionTypes.js
+++ b/packages/template/src/interbit/private/actionTypes.js
@@ -5,14 +5,4 @@ const actionTypes = {
   ADD: `${covenantName}/ADD`
 }
 
-// Export a proxy so an exception is thrown in case an undefined property is accessed
-module.exports = new Proxy(actionTypes, {
-  get: (obj, prop) => {
-    if (prop in obj) {
-      return obj[prop]
-    }
-    throw new Error(
-      `Invalid action type "${prop}" in covenant "${covenantName}"`
-    )
-  }
-})
+module.exports = actionTypes


### PR DESCRIPTION

The use of `Proxy` in PR #136 is an es6 feature.  This change ensures code under the `interbit` folder is es5, which unfortunately removes the proxy.