### PR TITLE
Add validation to Github chain action creators and update tests

### DIFF
--- a/packages/app-account/src/tests/covenants/github-kyc.covenant.test.js
+++ b/packages/app-account/src/tests/covenants/github-kyc.covenant.test.js
@@ -8,7 +8,8 @@ import covenant from '../../interbit/github-kyc'
 describe('github-kyc/covenant', () => {
   describe('reducer', () => {
     it('adds a new profile on UPDATE_PROFILE', () => {
-      const consumerChainId = '987654321'
+      const consumerChainId =
+        'b36b03cd329b0e7d5aae0b750b1116950b9b88abccbdeb6eb22d8205ebb13ce5'
       const profile = { id: 'ABC123', name: 'Joe Bloggs' }
 
       const action = covenant.actionCreators.updateProfile({
@@ -26,8 +27,9 @@ describe('github-kyc/covenant', () => {
 
     it('oAuthCallbackSaga works', async () => {
       const requestId = '1234'
-      const consumerChainId = '987654321'
-      const joinName = 'GITHUB-987654321'
+      const consumerChainId =
+        'b36b03cd329b0e7d5aae0b750b1116950b9b88abccbdeb6eb22d8205ebb13ce5'
+      const joinName = 'GITHUB-0003E343-787E-4C9C-B596-AED2B2BE41B9'
       const temporaryToken = 'TEMP-TOKEN-AAAAAAA'
       const accessToken = 'ACCESS-TOKEN-DDDDDDD'
       const gitHubProfile = {
@@ -50,10 +52,10 @@ describe('github-kyc/covenant', () => {
         oAuth: {
           shared: {
             params: {
-              client_id: 'CLIENT-ID'
+              client_id: '01234567890123456789'
             }
           },
-          client_secret: 'CLIENT-SECRET',
+          client_secret: '0123456789012345678901234567890123456789',
           tokenUrl: 'mock://github.com/login/oauth/access_token',
           profileUrl: 'mock://api.github.com/user'
         },


### PR DESCRIPTION
Tests use `validate` from `interbit-covenant-tools`. This takes as input the object to be validated and an object with the same property names with test methods that throw if the data does not match the test. The test methods are created by an immediately invoked function that accepts an optional message argument.

From the docs. Usage:
```js
const {
  validate,
  objectValidationRules: { required, faIconPattern, chainIdPattern }
} = require('@btlgroup/interbit-covenant-tools')

const actionTypes = {
  UPDATE_PROJECT: 'project/UPDATE_PROJECT',
  REGISTER_PROJECT: 'project/REGISTER_PROJECT'
}

const actionCreators = {
  updateProject: ({ projectName, description, icon, launchUrl }) => ({
    type: actionTypes.UPDATE_PROJECT,
    payload: validate(
      { projectName, description, icon, launchUrl },        // Object to validate
      { projectName: required(), icon: faIconPattern() }    // Validation rules attached to properties
    )
  }),

  registerProject: ({ parentChainId }) => ({
    type: actionTypes.REGISTER_PROJECT,
    payload: validate(
      { parentChainId },                       // Object to validate
      { parentChainId: chainIdPattern() }      // Validation rules attached to properties
    )
  })
}
```