### PR TITLE
Prevent oAuth join proliferation and fail fast on Github error

### DIFF
--- a/packages/app-account/src/interbit/github-kyc/actions.js
+++ b/packages/app-account/src/interbit/github-kyc/actions.js
@@ -19,14 +19,11 @@ const actionTypes = {
 }
 
 const GITHUB_CLIENT_ID_PATTERN = /^[0-9A-Fa-f]{20}$/
-const GITHUB_CLIENT_SECRET_PATTERN = /^[0-9A-Fa-f]{40}$/
 
 const actionCreators = {
   configureOauthApp: ({
     oldClientId,
     newClientId,
-    oldClientSecret,
-    newClientSecret,
     redirectUrl,
     scope = '',
     allowSignup = true
@@ -36,15 +33,12 @@ const actionCreators = {
       {
         oldClientId,
         newClientId,
-        oldClientSecret,
-        newClientSecret,
         redirectUrl,
         scope,
         allowSignup
       },
       {
         newCliendId: matches(GITHUB_CLIENT_ID_PATTERN),
-        newClientSecret: matches(GITHUB_CLIENT_SECRET_PATTERN),
         redirectUrl: required()
       }
     )

--- a/packages/app-account/src/interbit/github-kyc/actions.js
+++ b/packages/app-account/src/interbit/github-kyc/actions.js
@@ -1,5 +1,3 @@
-const uuid = require('uuid')
-
 const {
   validate,
   objectValidationRules: { required, matches, chainIdPattern, object }
@@ -16,14 +14,10 @@ const actionTypes = {
   AUTH_SUCEEDED: `${covenantName}/AUTH_SUCEEDED`,
   AUTH_FAILED: `${covenantName}/AUTH_FAILED`,
   UPDATE_PROFILE: `${covenantName}/UPDATE_PROFILE`,
-  SHARE_PROFILE: `${covenantName}/SHARE_PROFILE`,
   REMOVE_PROFILE: `${covenantName}/REMOVE_PROFILE`,
   SIGN_OUT: `${covenantName}/SIGN_OUT`
 }
 
-const generateJoinName = () => `GITHUB-${uuid.v4().toUpperCase()}`
-
-const GITHUB_JOIN_PATTERN = /^GITHUB-[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/
 const GITHUB_CLIENT_ID_PATTERN = /^[0-9A-Fa-f]{20}$/
 const GITHUB_CLIENT_SECRET_PATTERN = /^[0-9A-Fa-f]{40}$/
 
@@ -68,7 +62,6 @@ const actionCreators = {
       {
         requestId,
         consumerChainId,
-        joinName: generateJoinName(),
         temporaryToken,
         error,
         errorDescription
@@ -82,7 +75,6 @@ const actionCreators = {
   oAuthCallbackSaga: ({
     requestId,
     consumerChainId,
-    joinName,
     temporaryToken,
     error,
     errorDescription
@@ -92,7 +84,6 @@ const actionCreators = {
       {
         requestId,
         consumerChainId,
-        joinName,
         temporaryToken,
         error,
         errorDescription
@@ -155,20 +146,6 @@ const actionCreators = {
       {
         consumerChainId: chainIdPattern(),
         profile: object()
-      }
-    )
-  }),
-
-  shareProfile: ({ consumerChainId, joinName }) => ({
-    type: actionTypes.SHARE_PROFILE,
-    payload: validate(
-      {
-        consumerChainId,
-        joinName
-      },
-      {
-        consumerChainId: chainIdPattern(),
-        joinName: matches(GITHUB_JOIN_PATTERN)
       }
     )
   }),

--- a/packages/app-account/src/interbit/github-kyc/constants.js
+++ b/packages/app-account/src/interbit/github-kyc/constants.js
@@ -2,17 +2,28 @@ const {
   coreCovenant: { constants: coreConstants }
 } = require('interbit-covenant-tools')
 
+const OAUTH_ROOT = 'oAuth'
+const SHARED = 'shared'
+const PARAMS = 'params'
+const TOKEN_URL = 'tokenUrl'
+const PROFILE_URL = 'profileUrl'
+const CALLBACK_URL = 'callbackUrl'
+const CLIENT_ID = 'client_id'
+const REDIRECT_URL = 'redirect_uri'
+const SCOPE = 'scope'
+const ALLOW_SIGNUP = 'allow_signup'
+
 const PATHS = {
   ...coreConstants.PATHS,
-  OAUTH: ['oAuth'],
-  TOKEN_URL: ['oAuth', 'tokenUrl'],
-  PROFILE_URL: ['oAuth', 'profileUrl'],
-  CALLBACK_URL: ['oAuth', 'callbackUrl'],
-  PARAMS: ['oAuth', 'shared', 'params'],
-  CLIENT_ID: ['oAuth', 'shared', 'params', 'client_id'],
-  REDIRECT_URL: ['oAuth', 'shared', 'params', 'redirect_uri'],
-  SCOPE: ['oAuth', 'shared', 'params', 'scope'],
-  ALLOW_SIGNUP: ['oAuth', 'shared', 'params', 'allow_signup']
+  OAUTH: [OAUTH_ROOT],
+  TOKEN_URL: [OAUTH_ROOT, TOKEN_URL],
+  PROFILE_URL: [OAUTH_ROOT, PROFILE_URL],
+  CALLBACK_URL: [OAUTH_ROOT, CALLBACK_URL],
+  PARAMS: [OAUTH_ROOT, SHARED, PARAMS],
+  CLIENT_ID: [OAUTH_ROOT, SHARED, PARAMS, CLIENT_ID],
+  REDIRECT_URL: [OAUTH_ROOT, SHARED, PARAMS, REDIRECT_URL],
+  SCOPE: [OAUTH_ROOT, SHARED, PARAMS, SCOPE],
+  ALLOW_SIGNUP: [OAUTH_ROOT, SHARED, PARAMS, ALLOW_SIGNUP]
 }
 
 module.exports = { PATHS }

--- a/packages/app-account/src/interbit/github-kyc/constants.js
+++ b/packages/app-account/src/interbit/github-kyc/constants.js
@@ -1,0 +1,18 @@
+const {
+  coreCovenant: { constants: coreConstants }
+} = require('interbit-covenant-tools')
+
+const PATHS = {
+  ...coreConstants.PATHS,
+  OAUTH: ['oAuth'],
+  TOKEN_URL: ['oAuth', 'tokenUrl'],
+  PROFILE_URL: ['oAuth', 'profileUrl'],
+  CALLBACK_URL: ['oAuth', 'callbackUrl'],
+  PARAMS: ['oAuth', 'shared', 'params'],
+  CLIENT_ID: ['oAuth', 'shared', 'params', 'client_id'],
+  REDIRECT_URL: ['oAuth', 'shared', 'params', 'redirect_uri'],
+  SCOPE: ['oAuth', 'shared', 'params', 'scope'],
+  ALLOW_SIGNUP: ['oAuth', 'shared', 'params', 'allow_signup']
+}
+
+module.exports = { PATHS }

--- a/packages/app-account/src/interbit/github-kyc/index.js
+++ b/packages/app-account/src/interbit/github-kyc/index.js
@@ -88,6 +88,18 @@ const reducer = (state = initialState, action) => {
         errorDescription
       } = action.payload
 
+      if (error) {
+        const failedAction = actionCreators.authFailed({
+          requestId,
+          consumerChainId,
+          error: errorDescription || error
+        })
+
+        console.log('REDISPATCH: ', failedAction)
+        nextState = redispatch(nextState, failedAction)
+        return nextState
+      }
+
       if (
         authenticationRequestExists(state, {
           requestId,
@@ -177,6 +189,8 @@ const reducer = (state = initialState, action) => {
 }
 
 const authenticationRequestExists = (state, { requestId, temporaryToken }) =>
+  requestId &&
+  temporaryToken &&
   state.getIn(['authenticationRequests', requestId]) === temporaryToken
 
 const saveAuthenticationRequest = (state, { requestId, temporaryToken }) =>
@@ -343,7 +357,6 @@ function* fetchPublicProfile({ profileUrl, accessToken }, fetchApi) {
   }
 
   const profile = extractProfile(publicProfile)
-  console.log(profile)
 
   return profile
 }
@@ -355,7 +368,8 @@ const extractProfile = ({ login, id, name, avatar_url }) => ({
   id,
   login,
   name,
-  avatarUrl: avatar_url
+  avatarUrl: avatar_url,
+  timestamp: Date.now()
 })
 
 function* shareProfile({ consumerChainId }) {

--- a/packages/app-account/src/interbit/github-kyc/index.js
+++ b/packages/app-account/src/interbit/github-kyc/index.js
@@ -6,8 +6,7 @@ const {
   coreCovenant: {
     redispatch,
     actionCreators: { startProvideState },
-    selectors: coreSelectors,
-    constants: coreConstants
+    selectors: coreSelectors
   }
 } = require('interbit-covenant-tools')
 
@@ -15,32 +14,8 @@ const axios = require('axios')
 const { takeEvery, call, put, select } = require('redux-saga').effects
 
 const { actionTypes, actionCreators } = require('./actions')
-
-const paths = {
-  OAUTH: ['oAuth'],
-  TOKEN_URL: ['oAuth', 'tokenUrl'],
-  PROFILE_URL: ['oAuth', 'profileUrl'],
-  CALLBACK_URL: ['oAuth', 'callbackUrl'],
-  PARAMS: ['oAuth', 'shared', 'params'],
-  CLIENT_ID: ['oAuth', 'shared', 'params', 'client_id'],
-  REDIRECT_URL: ['oAuth', 'shared', 'params', 'redirect_uri'],
-  SCOPE: ['oAuth', 'shared', 'params', 'scope'],
-  ALLOW_SIGNUP: ['oAuth', 'shared', 'params', 'allow_signup']
-}
-
-const selectors = {
-  oAuthConfig: state => state.getIn(paths.OAUTH),
-  tokenUrl: state => state.getIn(paths.TOKEN_URL),
-  profileUrl: state => state.getIn(paths.PROFILE_URL),
-  callbackUrl: state => state.getIn(paths.CALLBACK_URL),
-  clientId: state => state.getIn(paths.CLIENT_ID),
-  params: state => state.getIn(paths.PARAMS),
-  redirectUrl: state => state.getIn(paths.REDIRECT_URL),
-  scope: state => state.getIn(paths.SCOPE),
-  allowSignup: state => state.getIn(paths.ALLOW_SIGNUP),
-
-  joinProviders: state => state.getIn(coreConstants.PATHS.PROVIDING, [])
-}
+const { PATHS } = require('./constants')
+const selectors = require('./selectors')
 
 const initialState = Immutable.from({
   chainMetadata: { chainName: 'Interbit Accounts - GitHub KYC Provider' },
@@ -93,10 +68,10 @@ const reducer = (state = initialState, action) => {
 
       if (!currentClientId || currentClientId === oldClientId) {
         nextState
-          .setIn(paths.CLIENT_ID, newClientId)
-          .setIn(paths.REDIRECT_URL, redirectUrl)
-          .setIn(paths.SCOPE, scope)
-          .setIn(paths.ALLOW_SIGNUP, allowSignup)
+          .setIn(PATHS.CLIENT_ID, newClientId)
+          .setIn(PATHS.REDIRECT_URL, redirectUrl)
+          .setIn(PATHS.SCOPE, scope)
+          .setIn(PATHS.ALLOW_SIGNUP, allowSignup)
 
         return nextState
       }

--- a/packages/app-account/src/interbit/github-kyc/selectors.js
+++ b/packages/app-account/src/interbit/github-kyc/selectors.js
@@ -1,0 +1,16 @@
+const { PATHS } = require('./constants')
+
+const selectors = {
+  oAuthConfig: state => state.getIn(PATHS.OAUTH),
+  tokenUrl: state => state.getIn(PATHS.TOKEN_URL),
+  profileUrl: state => state.getIn(PATHS.PROFILE_URL),
+  callbackUrl: state => state.getIn(PATHS.CALLBACK_URL),
+  clientId: state => state.getIn(PATHS.CLIENT_ID),
+  params: state => state.getIn(PATHS.PARAMS),
+  redirectUrl: state => state.getIn(PATHS.REDIRECT_URL),
+  scope: state => state.getIn(PATHS.SCOPE),
+  allowSignup: state => state.getIn(PATHS.ALLOW_SIGNUP),
+  joinProviders: state => state.getIn(PATHS.PROVIDING, [])
+}
+
+module.exports = selectors

--- a/packages/app-account/src/interbit/my-account/constants.js
+++ b/packages/app-account/src/interbit/my-account/constants.js
@@ -1,3 +1,7 @@
+const {
+  coreCovenant: { constants: coreConstants }
+} = require('interbit-covenant-tools')
+
 const SHARED_ROOT = 'shared'
 const SHARED_PROFILE = 'sharedProfile'
 const PRIVATE_PROFILE = 'profile'
@@ -7,6 +11,7 @@ const EMAIL = 'email'
 const NAME = 'name'
 
 const PATHS = {
+  ...coreConstants.PATHS,
   PRIVATE_PROFILE: [PRIVATE_PROFILE],
   SHARED_ROOT: [SHARED_ROOT],
   USERNAME: [PRIVATE_PROFILE, ALIAS],

--- a/packages/app-account/src/interbit/my-account/index.js
+++ b/packages/app-account/src/interbit/my-account/index.js
@@ -112,7 +112,11 @@ const reducer = (state = initialState, action) => {
         return state
       }
 
-      const existingJoin = findExistingJoin(state, { providerChainId })
+      const existingJoin = findExistingJoin(state, {
+        providerChainId,
+        joinName
+      })
+
       if (existingJoin) {
         console.log(`Join ${existingJoin.joinName} already configured.`)
       } else {
@@ -135,12 +139,10 @@ const reducer = (state = initialState, action) => {
   }
 }
 
-const findExistingJoin = (state, { providerChainId }) => {
-  // TODO: Move this to interbit-covenant-tools selectors
-  const joinConsumers = state.getIn(['interbit', 'config', 'consuming'], [])
+const findExistingJoin = (state, { providerChainId, joinName }) => {
+  const joinConsumers = state.getIn(PATHS.CONSUMING, [])
   return joinConsumers.find(
-    join =>
-      join.provider === providerChainId && join.joinName.startsWith('GITHUB-')
+    join => join.provider === providerChainId && join.joinName === joinName
   )
 }
 

--- a/packages/app-account/src/interbit/my-account/index.js
+++ b/packages/app-account/src/interbit/my-account/index.js
@@ -107,20 +107,25 @@ const reducer = (state = initialState, action) => {
       const { requestId, providerChainId, tokenName, joinName } = action.payload
 
       const request = state.getIn([...PATHS.AUTH_REQUESTS, requestId])
-
       if (!request) {
-        throw new Error('You did not originate this request')
+        console.log(`Request ${requestId} not found.`)
+        return state
       }
-      // TODO: Check for stale requests
 
-      const consumeAction = startConsumeState({
-        provider: providerChainId,
-        mount: [...PATHS.PRIVATE_PROFILE, tokenName],
-        joinName
-      })
+      const existingJoin = findExistingJoin(state, { providerChainId })
+      if (existingJoin) {
+        console.log(`Join ${existingJoin.joinName} already configured.`)
+      } else {
+        const consumeAction = startConsumeState({
+          provider: providerChainId,
+          mount: [...PATHS.PRIVATE_PROFILE, tokenName],
+          joinName
+        })
 
-      console.log('REDISPATCH: ', consumeAction)
-      nextState = redispatch(nextState, consumeAction)
+        console.log('REDISPATCH: ', consumeAction)
+        nextState = redispatch(nextState, consumeAction)
+      }
+
       nextState = removeAuthenticationRequest(nextState, requestId)
       return nextState
     }
@@ -128,6 +133,15 @@ const reducer = (state = initialState, action) => {
     default:
       return state
   }
+}
+
+const findExistingJoin = (state, { providerChainId }) => {
+  // TODO: Move this to interbit-covenant-tools selectors
+  const joinConsumers = state.getIn(['interbit', 'config', 'consuming'], [])
+  return joinConsumers.find(
+    join =>
+      join.provider === providerChainId && join.joinName.startsWith('GITHUB-')
+  )
 }
 
 const updateProfile = (state, { alias, name, email }) => {

--- a/packages/app-account/src/tests/covenants/github-kyc.covenant.test.js
+++ b/packages/app-account/src/tests/covenants/github-kyc.covenant.test.js
@@ -47,7 +47,6 @@ describe('github-kyc/covenant', () => {
         temporaryToken
       })
 
-      // const mockAxios = { post: () => {}, get: () => {} }
       const startingState = Immutable.from({
         oAuth: {
           shared: {
@@ -55,7 +54,6 @@ describe('github-kyc/covenant', () => {
               client_id: '01234567890123456789'
             }
           },
-          client_secret: '0123456789012345678901234567890123456789',
           tokenUrl: 'mock://github.com/login/oauth/access_token',
           profileUrl: 'mock://api.github.com/user'
         },
@@ -71,25 +69,34 @@ describe('github-kyc/covenant', () => {
           ],
           [matchers.call.fn(axios.get), { data: gitHubProfile }]
         ])
-        .put({
-          type: covenant.actionTypes.SHARE_PROFILE,
-          payload: { consumerChainId, joinName }
-        })
-        .put({
-          type: covenant.actionTypes.UPDATE_PROFILE,
-          payload: {
-            consumerChainId,
-            profile: {
-              id: gitHubProfile.id,
-              login: gitHubProfile.login,
-              name: gitHubProfile.name,
-              avatarUrl: gitHubProfile.avatar_url
+        .put.like({
+          action: {
+            type: '@@interbit/START_PROVIDE_STATE',
+            payload: {
+              consumer: consumerChainId,
+              statePath: ['profiles', consumerChainId, 'sharedProfile']
             }
           }
         })
-        .put({
-          type: covenant.actionTypes.AUTH_SUCEEDED,
-          payload: { requestId, joinName }
+        .put.like({
+          action: {
+            type: covenant.actionTypes.UPDATE_PROFILE,
+            payload: {
+              consumerChainId,
+              profile: {
+                id: gitHubProfile.id,
+                login: gitHubProfile.login,
+                name: gitHubProfile.name,
+                avatarUrl: gitHubProfile.avatar_url
+              }
+            }
+          }
+        })
+        .put.like({
+          action: {
+            type: covenant.actionTypes.AUTH_SUCEEDED,
+            payload: { requestId }
+          }
         })
         .run()
     })

--- a/packages/interbit-ui-tools/src/sagas/connections.js
+++ b/packages/interbit-ui-tools/src/sagas/connections.js
@@ -44,10 +44,7 @@ function* tryConnect({
       )
       console.log(`${LOG_PREFIX}: Connected to: ${toAddress}:${toPort}`)
     } catch (error) {
-      console.error(
-        `${LOG_PREFIX}: Connection failed: ${toAddress}:${toPort}: `,
-        error
-      )
+      console.error(`${LOG_PREFIX}: Connection failed: ${toAddress}:${toPort}`)
     }
   }
 }

--- a/packages/interbit/src/chainManagement/connectToPeers.js
+++ b/packages/interbit/src/chainManagement/connectToPeers.js
@@ -35,7 +35,7 @@ const tryConnect = async ({
       )
       console.log(`Connected to: ${toAddress}:${toPort}`)
     } catch (error) {
-      console.warn(`Connection failed: ${toAddress}:${toPort}: `, error)
+      console.warn(`Connection failed: ${toAddress}:${toPort}`)
     }
   }
 }

--- a/packages/web-auth-endpoint/src/oAuth.js
+++ b/packages/web-auth-endpoint/src/oAuth.js
@@ -42,7 +42,6 @@ const getRedirectUrl = (state, params = {}) => {
   const rootUrl = selectors.callbackUrl(state) || process.env.OAUTH_CALLBACK_URL
   const urlParams = queryString.stringify(params)
   const result = urlParams ? `${rootUrl}?${urlParams}` : rootUrl
-  console.log('getRedirectUrl', result)
   return result
 }
 
@@ -117,7 +116,6 @@ const waitForFinalSagaAction = (
     const tester = () => {
       state = chain.getState()
       block = chain.getCurrentBlock() || emptyBlock
-      console.log('tester', { state, block })
       return predicate(state, block)
     }
 


### PR DESCRIPTION
This PR contains a general tidying up of the GitHub oAuth and myAccount covenants.

1. No longer stores oAuth client secret in state
2. Fails fast if GitHub calls the oAuth callback with an error (such as altered redirect URLs). The error is passed to app-accounts as a URL parameter (previously this would timeout after 30s).
3. Checks for the existence of a join to the user's private chain and doesn't create a new one.
4. Profile sharing is handled by a generator function within the saga, rather than by dispatching an action.
5. Join name is generated within the saga, rather than being passed from an action creator.
6. No longer displays `You did not originate this request` errors in the UI.
7. If `connectToPeers` fails, displays a `connection failed` message rather than core errors with lots of obfuscation.

The UI updates will require a publish.