### PR TITLE
Covenant watch issue 181

### DIFF
--- a/docs/gitbook/reference/interbit-cli/start.md
+++ b/docs/gitbook/reference/interbit-cli/start.md
@@ -19,7 +19,7 @@ Coming soon:
 1. `--manifest` *(filepath)*: *Coming soon* the manifest file to use for variable resolution. If the manifest file contains genesis blocks they will be used to resolve the chain IDs of the started node. Default `[--artifacts]/interbit.manifest.json`
 1. `--artifacts` *(dirpath)*: the directory to search for a manifest in. Default `/dist`
 1. `--port` *(number)*: the port number Interbit will communicate on. Default 5000
-1. `--dev-mode` *(empty)*: a switch to indicate running in development mode. Development mode does not output an updated manifest and it watches covenants for updates, deploying the new covenants to the chains on change.
+1. `--dev-mode` *(empty)*: a switch to indicate running in development mode. Development mode does not output an updated manifest and it watches covenants for updates, deploying the new covenants to the configured static chains on change. *This does not update covenants applied to dynamic chains.*
 1. `--no-watch` *(empty)*: used only with `--dev-mode` this option stops the automatic covenant updates.
 
 #### Example

--- a/docs/gitbook/reference/interbit/README.md
+++ b/docs/gitbook/reference/interbit/README.md
@@ -2,7 +2,7 @@
 
 Interbit offers the same features as the `interbit-cli` but in small functions requireable for programmatically managing your chains.
 
-The Interbit package contains function to help you
+The `interbit` package contains function to help you
  - gather `interbit-cli` specific command line arguments
  - start Interbit nodes
  - create chains
@@ -18,7 +18,7 @@ Reference
 
 #### Options
 
-The main functions available in Interbit all accept a uniform `options` object that correspond to the CLI options used in the [`interbit-cli`](../interbit-cli/README.md) package.
+The main functions available in `interbit` all accept a uniform `options` object that correspond to the CLI options used in the [`interbit-cli`](../interbit-cli/README.md) package.
 
 Some options are not supported in every script and will be ignored. See the specific script/cli reference for supported options
 

--- a/docs/gitbook/reference/interbit/README.md
+++ b/docs/gitbook/reference/interbit/README.md
@@ -2,7 +2,7 @@
 
 Interbit offers the same features as the `interbit-cli` but in small functions requireable for programmatically managing your chains.
 
-The interbit package contains function to help you 
+The interbit package contains function to help you
  - gather `interbit-cli` specific command line arguments
  - start interbit nodes
  - create chains
@@ -16,3 +16,20 @@ Reference
  - [The Exports](https://github.com/interbit/interbit/blob/master/packages/interbit/src/index.js)
  - [The Package](https://www.npmjs.com/package/interbit)
 
+#### Options
+
+The main functions available in interbit all accept a uniform `options` object that correspond to the CLI options used in the [`interbit-cli`](../interbit-cli/README.md) package.
+
+Some options are not supported in every script and will be ignored. See the specific script/cli reference for supported options
+
+  - `keyPair` *(Object)*: A keypair object to boot the hypervisor with.
+      - `publicKey` *(String)*  The public key
+      - `privateKey` *(String)* The private key
+  - `location` *(string)*: The working directory for this function/script
+  - `manifest` *(Object)*: The contents of the loaded [manifest](../interbit-cli/manifest.md) file
+  - `config` *(Object)*: The contents of the loaded [config](../interbit-cli/config.md) file
+  - `port` *(number)*: The port for Interbit to communicate on
+  - `dbPath` *(string)* The path to the database Interbit is using for this node
+  - `connect` *(bool)*: Whether this node is simply connecting to other already running instances, or should do the deployment configuration of joins/covenants etc. itself.
+  - `isWatchModeEnabled` *(bool)*: Whether watch mode is enabled. Defaults to true
+  - `isDevModeEnabled` *(bool)*: Whether dev mode is enabled. Defaults to false

--- a/docs/gitbook/reference/interbit/README.md
+++ b/docs/gitbook/reference/interbit/README.md
@@ -2,9 +2,9 @@
 
 Interbit offers the same features as the `interbit-cli` but in small functions requireable for programmatically managing your chains.
 
-The interbit package contains function to help you
+The Interbit package contains function to help you
  - gather `interbit-cli` specific command line arguments
- - start interbit nodes
+ - start Interbit nodes
  - create chains
  - configure chains
  - manage covenants
@@ -18,7 +18,7 @@ Reference
 
 #### Options
 
-The main functions available in interbit all accept a uniform `options` object that correspond to the CLI options used in the [`interbit-cli`](../interbit-cli/README.md) package.
+The main functions available in Interbit all accept a uniform `options` object that correspond to the CLI options used in the [`interbit-cli`](../interbit-cli/README.md) package.
 
 Some options are not supported in every script and will be ignored. See the specific script/cli reference for supported options
 

--- a/packages/interbit-cli/scripts/keys.js
+++ b/packages/interbit-cli/scripts/keys.js
@@ -5,6 +5,14 @@ const { getArg } = require('interbit')
 
 const keys = async () => {
   const filenameOption = getArg(process.argv, '--filename')
+
+  if (!filenameOption) {
+    console.error(
+      '"interbit keys" command must be used with a --filename option'
+    )
+    process.exit(1)
+  }
+
   const keyPair = await interbit.generateKeyPair()
   const filename = filenameOption.endsWith('.json')
     ? path.resolve(filenameOption)

--- a/packages/interbit-cli/scripts/start.js
+++ b/packages/interbit-cli/scripts/start.js
@@ -21,6 +21,9 @@ const startInterbitNode = async () => {
     console.log(logo)
 
     const options = getOptions(process.argv)
+
+    console.log('Running with options', JSON.stringify(options, null, 2))
+
     const interbitConfig = getConfig()
 
     // eslint-disable-next-line

--- a/packages/interbit/src/chainManagement/watchCovenants.js
+++ b/packages/interbit/src/chainManagement/watchCovenants.js
@@ -35,6 +35,7 @@ const redeployBuffer = {
 }
 
 const redeployCovenants = async (cli, interbitConfig, chainManifest) => {
+  console.log('attempted to redeploy')
   if (redeployBuffer.isDeploying) {
     redeployBuffer.isDeployPending = true
     return undefined
@@ -67,12 +68,12 @@ const applyUpdates = (cli, chainManifest, interbitConfig, covenantHashes) => {
     const isDefaultChain = aliasedChain.isDefaultChain
     if (isDefaultChain) {
       const defaultChain = await cli.getChain(chainEntry.chainId)
-      updateProdConfig(chainManifest, covenantHashes, defaultChain)
+      updateManifest(chainManifest, covenantHashes, defaultChain)
     }
   })
 }
 
-const updateProdConfig = (chainManifest, covenantHashes, defaultChain) => {
+const updateManifest = (chainManifest, covenantHashes, defaultChain) => {
   const deploymentDetails = generateDeploymentDetails(
     chainManifest,
     covenantHashes

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -36,7 +36,7 @@
         "serve": "cross-env serve --single build",
         "test": "react-scripts test --env=jsdom",
         "eject": "react-scripts eject",
-        "interbit:start": "interbit start --db-path ./db-interbit --port 5000 --dev --no-watch",
+        "interbit:start": "interbit start --db-path ./db-interbit --port 5000 --dev",
         "interbit:create": "interbit create --dev",
         "interbit:build": "interbit build",
         "interbit:deploy": "interbit deploy --admin-keys keyPair.js"


### PR DESCRIPTION
- Document how start --dev works more clearly
- Improve logging messages in interbit-cli
- enable watch mode on interbit:start in template app

If watch mode still does not work for you please refer to issue #181 for a Linux system level fix.

Closes #181 