### PR TITLE
Use GitBook's "label@path" syntax to avoid copying the theme.

### DIFF
--- a/docs/gitbook/book.json
+++ b/docs/gitbook/book.json
@@ -8,7 +8,7 @@
         "exercises",
         "expandable-chapters-small",
         "prism",
-        "theme-interbit"
+        "theme-interbit@../gitbook-plugin-theme-interbit"
     ],
     "variables": {
         "themeInterbit": {

--- a/docs/package.sh
+++ b/docs/package.sh
@@ -8,7 +8,4 @@ THEME_DIR=$SDK_DIR/gitbook-plugin-theme-interbit
 # Install and build gitbook
 cd $SDK_DIR/gitbook
 gitbook install
-# Install will fail to install our theme plugin, it must be copied into node_modules
-# This will be fixed once the plugin is a public package
-cp -r $THEME_DIR $SDK_DIR/gitbook/node_modules
 gitbook build


### PR DESCRIPTION
This lets us use the theme in its currently location, so we no longer need to copy it into `node_modules`.