### PR TITLE
Use relative paths for CSS-specified images, so sub-dir serving works.

### DIFF
--- a/docs/gitbook-plugin-theme-interbit/_assets/website/interbit.css
+++ b/docs/gitbook-plugin-theme-interbit/_assets/website/interbit.css
@@ -339,7 +339,7 @@ img.support-icon {
 }
 
 .info span:not(.token) {
-  content: url('/assets/img/info.png');
+  content: url('../../assets/img/info.png');
 }
 
 
@@ -354,7 +354,7 @@ img.support-icon {
 }
 
 .warning span {
-  content: url('/assets/img/warning.png');
+  content: url('../../assets/img/warning.png');
 }
 
 /*TIPS -WARNING STYLE*/
@@ -368,7 +368,7 @@ img.support-icon {
 }
 
 .danger span {
-  content: url('/assets/img/danger.png');
+  content: url('../../assets/img/danger.png');
 }
 
 /*TIPS -WARNING STYLE*/
@@ -382,7 +382,7 @@ img.support-icon {
 }
 
 .success span {
-  content: url('/assets/img/success.png');
+  content: url('../../assets/img/success.png');
 }
 
 pre.exercise-pre {


### PR DESCRIPTION
This change makes it easier for me to preview various GitBook rendering of the docs in a sub-directory so that I don't have to setup DNS to access each rendering.