### PR TITLE
Fix deploy write join bug

### DIFF
--- a/packages/interbit/src/chainManagement/configureJoins.js
+++ b/packages/interbit/src/chainManagement/configureJoins.js
@@ -65,14 +65,17 @@ const configureReceive = (receive, interbitManifest) => {
   if (!Array.isArray(receive)) {
     return []
   }
-  return receive.reduce((prev, { alias: chainAlias, authorizedActions }) => {
-    const senderChainId = getChainIdByAlias(chainAlias, interbitManifest)
-    const receiveAction = authorizeReceiveActions({
-      senderChainId,
-      authorizedActions
-    })
-    return prev.concat(receiveAction)
-  }, [])
+  return receive.reduce(
+    (prev, { alias: chainAlias, authorizedActions: permittedActions }) => {
+      const senderChainId = getChainIdByAlias(chainAlias, interbitManifest)
+      const receiveAction = authorizeReceiveActions({
+        senderChainId,
+        permittedActions
+      })
+      return prev.concat(receiveAction)
+    },
+    []
+  )
 }
 
 const configureSend = (send, interbitManifest) => {

--- a/packages/interbit/src/chainManagement/joinChains.js
+++ b/packages/interbit/src/chainManagement/joinChains.js
@@ -115,6 +115,10 @@ const establishReceiveActions = async (
       console.warn(`Unknown alias: ${alias}`)
       continue
     }
+    if (!authorizedActions) {
+      console.warn(`No authorized actions for write join to: ${alias}`)
+      continue
+    }
     const { chainId: senderChainId } = manifest[alias]
     const authorizeReceiveAction = authorizeReceiveActions({
       senderChainId,

--- a/packages/interbit/src/tests/chainManagement/configureJoins.test.js
+++ b/packages/interbit/src/tests/chainManagement/configureJoins.test.js
@@ -85,7 +85,7 @@ describe('configureJoins(chainInterface, joins, manifest)', () => {
       type: '@@interbit/AUTHORIZE_RECEIVE_ACTIONS',
       payload: {
         senderChainId: manifest.chains.lemongrasschicken,
-        permittedActions: joins.receiveActionFrom[0].path
+        permittedActions: joins.receiveActionFrom[0].authorizedActions
       }
     }
 


### PR DESCRIPTION
Problem caused not mapping `authorizedActions` to `permittedActions` in the action creator., and a not too helpful test that compared `unassigned` with `unassigned`.