### PR TITLE
Deploy root chain 371

### DIFF
--- a/packages/app-todo-list/src/tests/exports.test.js
+++ b/packages/app-todo-list/src/tests/exports.test.js
@@ -9,7 +9,7 @@ describe('module exports expected API', () => {
     assert.ok(api.publicCovenant.reducer)
   })
 
-  it('manifestCovenant', () => {
+  it('privateCovenant', () => {
     assert.ok(api.privateCovenant)
     assert.ok(api.privateCovenant.actionCreators)
     assert.ok(api.privateCovenant.actionTypes)

--- a/packages/interbit-covenant-tools/package.json
+++ b/packages/interbit-covenant-tools/package.json
@@ -10,6 +10,9 @@
     "dev": "webpack --progress --colors --watch --env dev",
     "test": "mocha \"src/tests/**/*.test.js\""
   },
+  "files": [
+    "src/rootCovenant"
+  ],
   "author": "BTL GROUP LTD",
   "license": "MIT",
   "devDependencies": {

--- a/packages/interbit-covenant-tools/src/index.js
+++ b/packages/interbit-covenant-tools/src/index.js
@@ -4,11 +4,7 @@ const { createAction } = require('interbit-covenant-utils')
 const coreCovenant = require('./coreCovenant')
 const constants = require('./constants')
 
-const {
-  manifestCovenant,
-  rootCovenant,
-  rootStateSelectors
-} = require('./rootCovenant')
+const { rootStateSelectors, ...rest } = require('./rootCovenant')
 
 const cAuthConsumerCovenant = require('./cAuthConsumerCovenant')
 const config = require('./config')
@@ -27,8 +23,7 @@ module.exports = {
   constants,
   coreCovenant,
   manifest,
-  manifestCovenant,
-  rootCovenant,
+  rootCovenant: rest,
   rootStateSelectors,
   cAuthConsumerCovenant,
   mergeCovenants,

--- a/packages/interbit-covenant-tools/src/rootCovenant/index.js
+++ b/packages/interbit-covenant-tools/src/rootCovenant/index.js
@@ -1,10 +1,8 @@
 // © 2018 BTL GROUP LTD -  This package is licensed under the MIT license https://opensource.org/licenses/MIT
-const manifestCovenant = require('./covenants/manifestCovenant')
 const rootCovenant = require('./covenants/rootCovenant')
 const rootStateSelectors = require('./rootStateSelectors')
 
 module.exports = {
-  manifestCovenant,
-  rootCovenant,
-  rootStateSelectors
+  rootStateSelectors,
+  ...rootCovenant
 }

--- a/packages/interbit-covenant-tools/src/rootCovenant/package.json
+++ b/packages/interbit-covenant-tools/src/rootCovenant/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "interbit-root-covenant",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "BTL GROUP LTD",
+  "license": "MIT",
+  "dependencies": {
+    "json-stable-stringify": "^1.0.1",
+    "object-hash": "^1.3.0",
+    "seamless-immutable": "^7.1.3"
+  }
+}

--- a/packages/interbit-covenant-tools/src/tests/exports.test.js
+++ b/packages/interbit-covenant-tools/src/tests/exports.test.js
@@ -34,17 +34,10 @@ describe('module exports expected API', () => {
     assert.ok(api.coreCovenant.selectors.config)
   })
 
-  it('manifestCovenant', () => {
-    assert.ok(api.manifestCovenant)
-    assert.ok(api.manifestCovenant.actionCreators)
-    assert.ok(api.manifestCovenant.actionTypes)
-    assert.ok(api.manifestCovenant.initialState)
-    assert.ok(api.manifestCovenant.reducer)
-  })
-
   it('rootCovenant', () => {
     assert.ok(api.rootCovenant)
     assert.ok(api.rootCovenant.actionCreators)
+    assert.ok(api.rootCovenant.actionCreators.setManifest)
     assert.ok(api.rootCovenant.actionTypes)
     assert.ok(api.rootCovenant.initialState)
     assert.ok(api.rootCovenant.reducer)

--- a/packages/interbit-covenant-tools/src/tests/rootCovenant/rootCovenant.test.js
+++ b/packages/interbit-covenant-tools/src/tests/rootCovenant/rootCovenant.test.js
@@ -3,7 +3,7 @@ const should = require('should')
 const {
   selectors: { pendingActionsForChain }
 } = require('../../coreCovenant')
-const { rootCovenant } = require('../../rootCovenant')
+const rootCovenant = require('../../rootCovenant')
 const defaultManifest = require('../testManifest.json')
 
 describe('rootCovenant', () => {

--- a/packages/interbit-template/src/tests/exports.test.js
+++ b/packages/interbit-template/src/tests/exports.test.js
@@ -9,7 +9,7 @@ describe('module exports expected API', () => {
     assert.ok(api.publicCovenant.reducer)
   })
 
-  it('manifestCovenant', () => {
+  it('privateCovenant', () => {
     assert.ok(api.privateCovenant)
     assert.ok(api.privateCovenant.actionCreators)
     assert.ok(api.privateCovenant.actionTypes)

--- a/packages/interbit/src/chainManagement/configureChains.js
+++ b/packages/interbit/src/chainManagement/configureChains.js
@@ -1,5 +1,5 @@
 const {
-  manifestCovenant: {
+  rootCovenant: {
     actionCreators: { setManifest }
   },
   manifest: {

--- a/packages/interbit/src/chainManagement/setRootChainManifest.js
+++ b/packages/interbit/src/chainManagement/setRootChainManifest.js
@@ -1,5 +1,5 @@
 const {
-  manifestCovenant: { actionCreators },
+  rootCovenant: { actionCreators },
   manifest: {
     selectors: { getChainIdByAlias }
   },

--- a/packages/interbit/src/file/index.js
+++ b/packages/interbit/src/file/index.js
@@ -3,11 +3,13 @@ const {
   updateDom,
   camelCaseToHyphenated
 } = require('./updateIndexHtml')
+const { packCovenants } = require('./packCovenants')
 const watchCovenants = require('./watchCovenants')
 const writeJsonFile = require('./writeJsonFile')
 
 module.exports = {
   camelCaseToHyphenated,
+  packCovenants,
   updateDom,
   updateIndexHtmls,
   watchCovenants,

--- a/packages/interbit/src/file/packCovenants.js
+++ b/packages/interbit/src/file/packCovenants.js
@@ -1,0 +1,73 @@
+const fs = require('fs-extra')
+const promisify = require('util').promisify
+const exec = promisify(require('child_process').exec)
+const path = require('path')
+const {
+  constants: { ROOT_CHAIN_ALIAS }
+} = require('interbit-covenant-tools')
+
+const { startInterbit } = require('../chainManagement')
+
+// Note: Because interbit-core does not expose it's hashing function (yet) we ned to
+// start a cli and deploy the covenants to get a valid hash that is in sync with interbit
+// TODO: update this to use the hashing function instead of starting a CLI -- Blocked until core releases hashing algo in API
+const packCovenants = async (location, covenantConfig) => {
+  const { cli } = await startInterbit()
+
+  const packedCovenants = {}
+  const covenants = Object.entries(covenantConfig)
+  console.log('PACKING COVENANTS', covenants)
+  for (const [covenantAlias, config] of covenants) {
+    console.log(`...packing ${covenantAlias} from ${config.location}`)
+    const packedCovenant = await packCovenant(cli, location, config.location)
+
+    packedCovenants[covenantAlias] = packedCovenant
+  }
+
+  packedCovenants[ROOT_CHAIN_ALIAS] = await packRootCovenant(cli, location)
+
+  // TODO: Kill this thang properly (Blocked: #341)
+  cli.stopServer()
+
+  return packedCovenants
+}
+
+const packCovenant = async (cli, location, covenantFileLocation) => {
+  const covenantLocation = path.relative(process.cwd(), covenantFileLocation)
+
+  await exec(`npm pack ./${covenantLocation}`)
+
+  // eslint-disable-next-line
+  const covenantPackageJson = require(`${covenantFileLocation}/package.json`)
+  const packedFilename = `${covenantPackageJson.name}-${
+    covenantPackageJson.version
+  }.tgz`
+
+  const hash = await cli.deployCovenant(covenantFileLocation)
+  fs.moveSync(packedFilename, `${location}/covenants/${hash}.tgz`)
+
+  return {
+    hash,
+    filename: `covenants/${hash}.tgz`
+  }
+}
+
+const packRootCovenant = async (cli, location) => {
+  const packageName = 'interbit-covenant-tools'
+
+  const rootCovenantLocation = path.join(
+    getPackageDirFromFilePath(packageName, require.resolve(packageName)),
+    '/src/rootCovenant'
+  )
+
+  const covenantInfo = await packCovenant(cli, location, rootCovenantLocation)
+
+  return covenantInfo
+}
+
+const getPackageDirFromFilePath = (packageName, filepath) =>
+  filepath.substr(0, filepath.indexOf(packageName) + packageName.length)
+
+module.exports = {
+  packCovenants
+}

--- a/packages/interbit/src/file/packCovenants.js
+++ b/packages/interbit/src/file/packCovenants.js
@@ -44,7 +44,7 @@ const packCovenant = async (cli, location, covenantFileLocation) => {
   }.tgz`
 
   const hash = await cli.deployCovenant(covenantFileLocation)
-  fs.moveSync(packedFilename, `${location}/covenants/${hash}.tgz`)
+  await fs.move(packedFilename, `${location}/covenants/${hash}.tgz`)
 
   return {
     hash,

--- a/packages/interbit/src/manifest/index.js
+++ b/packages/interbit/src/manifest/index.js
@@ -1,5 +1,9 @@
 const { generateManifest } = require('./generateManifest')
+const {
+  manifest: { selectors }
+} = require('interbit-covenant-tools')
 
 module.exports = {
-  generateManifest
+  generateManifest,
+  manifestSelectors: selectors
 }

--- a/packages/interbit/src/scripts/build.js
+++ b/packages/interbit/src/scripts/build.js
@@ -1,11 +1,8 @@
 const fs = require('fs-extra')
-const promisify = require('util').promisify
-const exec = promisify(require('child_process').exec)
 const path = require('path')
 
-const { startInterbit } = require('../chainManagement')
 const { generateManifest } = require('../manifest')
-const { updateIndexHtmls, writeJsonFile } = require('../file')
+const { updateIndexHtmls, writeJsonFile, packCovenants } = require('../file')
 
 const build = async options => {
   const { config, manifest, artifacts } = options
@@ -38,38 +35,6 @@ const build = async options => {
 const setupDist = location => {
   fs.removeSync(location)
   fs.mkdirpSync(location)
-}
-
-const packCovenants = async (location, covenantConfig) => {
-  const { cli } = await startInterbit()
-
-  const packedCovenants = {}
-  const covenants = Object.entries(covenantConfig)
-  console.log('PACKING COVENANTS', covenants)
-  for (const [covenantAlias, config] of covenants) {
-    const covenantLocation = path.relative(process.cwd(), config.location)
-    console.log(`...packing ${covenantAlias} from ${covenantLocation}`)
-    await exec(`npm pack ./${covenantLocation}`)
-
-    // eslint-disable-next-line
-    const covenantPackageJson = require(`${config.location}/package.json`)
-    const packedFilename = `${covenantPackageJson.name}-${
-      covenantPackageJson.version
-    }.tgz`
-
-    const hash = await cli.deployCovenant(config.location)
-    fs.moveSync(packedFilename, `${location}/covenants/${hash}.tgz`)
-
-    packedCovenants[covenantAlias] = {
-      hash,
-      filename: `covenants/${hash}.tgz`
-    }
-  }
-
-  // TODO: Kill this thang properly (Blocked: #341)
-  cli.stopServer()
-
-  return packedCovenants
 }
 
 module.exports = build

--- a/packages/interbit/src/scripts/deploy.js
+++ b/packages/interbit/src/scripts/deploy.js
@@ -8,9 +8,11 @@ const deploy = async options => {
   const { keyPair, port, location, manifest, connect } = options
 
   const { cli } = await startInterbit(keyPair, { port })
+
   // TODO: Refactor deployCovenants to its own function and move options up into here
   // Rename connect to configure and invert it so it makes more sense. ATM this is backwards
-  // compatible with other uses of deploy throughout the code (Issue #39)
+  // compatible with other uses of deploy throughout the code
+
   await createChainsFromManifest(location, cli, manifest, options)
 
   if (!connect) {


### PR DESCRIPTION
Build the root covenant, deploy it, and deploy the root chain with permissions to cascade manifest updates.

Closes #371 

There was some refactoring necessary to achieve this. Since the rootCovenant is inside another package and to be deployable it needs to be an npm package, the exports inside of src/rootCovenant were massaged to allow the packing and deploying of the root covenant without modifying the exported interbit-covenant-tools API significantly.

The only change to the API (Export tests and references have been updated) was the removal of the manifestCovenant, which is itself a subset of the rootCovenant and thus can be used via the rootCovenant (as is demonstrated in the rootCovenant tests)

### Things to look for in this PR...

Refactoring:
- refactor `interbit/src/file/packCovenants.js` to its own file
- restructure `interbit-covenant-tools/src/rootCovenant/*` to a deployable package
- modify `interbit-covenant-tools/src/rootCovenant/index.js` exports so rootCovenant is deployable
- remove manifestCovenant export from interbit-covenant-tools (it is a subset of rootCovenant and redundant) and update usages to use rootCovenant instead
- update tests to reflect changes 
- test to ensure things being used externally from manifestCovenant are, in fact, exported by rootCovenant and stay that way

New Stuff:
- pack and build the root covenant during interbit build step
- deploy the root covenant during deploy step
- the chain was already being created during deploy from a previous commit