### PR TITLE
fix(interbit): replace joinTypes reference

### DIFF
--- a/packages/interbit/src/chainManagement/joinChains.js
+++ b/packages/interbit/src/chainManagement/joinChains.js
@@ -8,8 +8,9 @@ const {
     }
   },
   config: {
-    selectors: { getChainJoins, getJoinTypeForChain, joinTypes }
-  }
+    selectors: { getChainJoins, getJoinTypeForChain }
+  },
+  constants: { JOIN_TYPES }
 } = require('interbit-covenant-tools')
 
 // SET FOR DEPRECATION: Pending issue #79
@@ -21,22 +22,22 @@ const joinChains = async (manifest, cli, config) => {
       if (getChainJoins(chainAlias, config)) {
         const provide = getJoinTypeForChain(
           chainAlias,
-          joinTypes.PROVIDE,
+          JOIN_TYPES.PROVIDE,
           config
         )
         const consume = getJoinTypeForChain(
           chainAlias,
-          joinTypes.CONSUME,
+          JOIN_TYPES.CONSUME,
           config
         )
         const sendActionTo = getJoinTypeForChain(
           chainAlias,
-          joinTypes.SEND,
+          JOIN_TYPES.SEND,
           config
         )
         const receiveActionFrom = getJoinTypeForChain(
           chainAlias,
-          joinTypes.RECEIVE,
+          JOIN_TYPES.RECEIVE,
           config
         )
 


### PR DESCRIPTION
The Interbit backend was broken because of how the joinTypes were referenced in `packages/interbit`. 

@nicholeous I've verified that the backends start up for our all our apps in `packages` and also `interbit-template`. 