### PR TITLE
Run build:modules on postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "cross-env-shell lerna run --scope $APP_NAME build",
     "build:modules": "lerna run --scope interbit-* build",
-    "postinstall": "lerna bootstrap --hoist --parallel",
+    "postinstall": "lerna bootstrap --hoist --parallel && npm run build:modules",
     "heroku-postbuild": "npm run build:modules && npm run build",
     "start": "cross-env-shell lerna run --scope $APP_NAME serve --stream",
     "test": "npm run lint && lerna run --parallel test -- -- --coverage",

--- a/packages/utils/src/standards/std.package.json
+++ b/packages/utils/src/standards/std.package.json
@@ -4,12 +4,12 @@
   "dependencies": {
     "cross-env": "^5.1.4",
     "lerna": "^2.10.2",
-    "tar":"^4.4.2"
+    "tar": "^4.4.2"
   },
   "scripts": {
     "build": "cross-env-shell lerna run --scope $APP_NAME build",
     "build:modules": "lerna run --scope interbit-* build",
-    "postinstall": "lerna bootstrap --hoist --parallel",
+    "postinstall": "lerna bootstrap --hoist --parallel && npm run build:modules",
     "heroku-postbuild": "npm run build:modules && npm run build",
     "start": "cross-env-shell lerna run --scope $APP_NAME serve --stream",
     "test": "npm run lint && lerna run --parallel test -- -- --coverage",


### PR DESCRIPTION
Instead of always having to run build:modules, automagically run it postinstall.

Packages will still need to be built when you've changed them for testing integrations etc.