### PR TITLE
Update interbit-core to 0.14.0

### DIFF
--- a/packages/app-account/public/index.html
+++ b/packages/app-account/public/index.html
@@ -19,7 +19,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-  <script src="https://unpkg.com/interbit-core@0.13.0/dist/bundle.browser.js"></script>
+  <script src="https://unpkg.com/interbit-core@0.14.0/dist/bundle.browser.js"></script>
   <title>Interbit Account</title>
 </head>
 

--- a/packages/app-app-store/public/index.html
+++ b/packages/app-app-store/public/index.html
@@ -20,7 +20,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <script src="https://unpkg.com/interbit-core@0.13.0/dist/bundle.browser.js"></script>
+    <script src="https://unpkg.com/interbit-core@0.14.0/dist/bundle.browser.js"></script>
     <title>Interbit Store</title>
 </head>
 

--- a/packages/app-project/public/index.html
+++ b/packages/app-project/public/index.html
@@ -20,7 +20,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <script src="https://unpkg.com/interbit-core@0.13.0/dist/bundle.browser.js"></script>
+    <script src="https://unpkg.com/interbit-core@0.14.0/dist/bundle.browser.js"></script>
     <title>Interbit Hosting</title>
 </head>
 

--- a/packages/app-sdk-incrementer/public/index.html
+++ b/packages/app-sdk-incrementer/public/index.html
@@ -20,7 +20,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <script src="https://unpkg.com/interbit-core@0.13.0/dist/bundle.browser.js"></script>
+    <script src="https://unpkg.com/interbit-core@0.14.0/dist/bundle.browser.js"></script>
     <title>Interbit Application Template</title>
 </head>
 

--- a/packages/app-todo-list/public/index.html
+++ b/packages/app-todo-list/public/index.html
@@ -20,7 +20,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-  <script src="https://unpkg.com/interbit-core@0.13.0/dist/bundle.browser.js"></script>
+  <script src="https://unpkg.com/interbit-core@0.14.0/dist/bundle.browser.js"></script>
   <title>Interbit App - To-do List</title>
 </head>
 

--- a/packages/app-uth-ex/public/index.html
+++ b/packages/app-uth-ex/public/index.html
@@ -20,7 +20,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <script src="https://unpkg.com/interbit-core@0.13.0/dist/bundle.browser.js"></script>
+    <script src="https://unpkg.com/interbit-core@0.14.0/dist/bundle.browser.js"></script>
     <title>Interbit Application Template</title>
 </head>
 

--- a/packages/interbit-cli/package.json
+++ b/packages/interbit-cli/package.json
@@ -18,6 +18,6 @@
     "cross-spawn": "5.1.0",
     "fs-extra": "^5.0.0",
     "interbit": "0.4.31",
-    "interbit-core": "0.13.0"
+    "interbit-core": "0.14.0"
   }
 }

--- a/packages/interbit-covenant-tools/package.json
+++ b/packages/interbit-covenant-tools/package.json
@@ -30,7 +30,7 @@
     "yargs": "^10.0.3"
   },
   "dependencies": {
-    "interbit-covenant-utils": "0.13.0",
+    "interbit-covenant-utils": "0.14.0",
     "json-stable-stringify": "^1.0.1",
     "object-hash": "^1.3.0",
     "seamless-immutable": "^7.1.2"

--- a/packages/interbit-template/public/index.html
+++ b/packages/interbit-template/public/index.html
@@ -20,7 +20,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-  <script src="https://unpkg.com/interbit-core@0.13.0/dist/bundle.browser.js"></script>
+  <script src="https://unpkg.com/interbit-core@0.14.0/dist/bundle.browser.js"></script>
   <title>Interbit Application Template</title>
 </head>
 

--- a/packages/interbit-test/package.json
+++ b/packages/interbit-test/package.json
@@ -9,7 +9,7 @@
   "author": "BTL GROUP LTD",
   "license": "MIT",
   "dependencies": {
-    "interbit-core": "0.13.0"
+    "interbit-core": "0.14.0"
   },
   "devDependencies": {
     "assert": "^1.4.1",

--- a/packages/interbit-test/test/genesisBlocks.test.js
+++ b/packages/interbit-test/test/genesisBlocks.test.js
@@ -59,7 +59,8 @@ describe('chain sponsorship', () => {
     ],
     acl: {
       actionPermissions: {
-        '*': ['root', `chain-${sponsorChainId}`]
+        '*': ['root', `chain-${sponsorChainId}`],
+        '@@interbit/REMOVE_JOIN_CONFIG': [`chain-${sponsorChainId}`]
       },
       roles: {
         root: [blockMasterPublicKey, myPublicKey],

--- a/packages/interbit-test/test/interbit.test.js
+++ b/packages/interbit-test/test/interbit.test.js
@@ -78,7 +78,8 @@ describe('interbit', () => {
         setHeavyBlockInterval: 'function',
         waitForState: 'function',
         chainId: 'string',
-        keyPair: 'object'
+        keyPair: 'object',
+        blockSubscribe: 'function'
       }
 
       verifyApi(hypervisor, expectedHypervisorApi)
@@ -110,8 +111,6 @@ describe('interbit', () => {
           createGenesisBlock: 'function',
           getState: 'function',
           subscribe: 'function',
-          kvPut: 'function',
-          kvGet: 'function',
           sendChainToSponsor: 'function',
           deployCovenant: 'function',
           applyCovenant: 'function',
@@ -120,7 +119,7 @@ describe('interbit', () => {
           shutdown: 'function',
           destroyChain: 'function',
           stats: 'function',
-          test: 'function'
+          kvGetKeys: 'function'
         }
 
         verifyApi(cli, expectedCliApi)
@@ -142,7 +141,9 @@ describe('interbit', () => {
             dispatch: 'function',
             getState: 'function',
             getCurrentBlock: 'function',
-            subscribe: 'function'
+            subscribe: 'function',
+            blockSubscribe: 'function',
+            getCachedBlocks: 'function'
           }
 
           verifyApi(chain, expectedChainApi)

--- a/packages/interbit-ui-tools/package.json
+++ b/packages/interbit-ui-tools/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "base64-url": "^2.2.0",
+    "localforage": "^1.7.2",
     "lodash": "^4.17.5",
     "query-string": "^5.0.1",
     "redux-saga": "^0.16.0",

--- a/packages/interbit-ui-tools/src/actions.js
+++ b/packages/interbit-ui-tools/src/actions.js
@@ -13,6 +13,7 @@ const actionTypes = {
   SPONSOR_CHAIN_SAGA: `${ACTION_PREFIX}/SPONSOR_CHAIN_SAGA`,
 
   CHAIN_UPDATED: `${ACTION_PREFIX}/CHAIN_UPDATED`,
+  CHAIN_NEW_BLOCK: `${ACTION_PREFIX}/CHAIN_NEW_BLOCK`,
   CHAIN_DISPATCH: `${ACTION_PREFIX}/CHAIN_DISPATCH`,
   CHAIN_SPONSORING: `${ACTION_PREFIX}/CHAIN_SPONSORING`,
   CHAIN_LOADING: `${ACTION_PREFIX}/CHAIN_LOADING`,
@@ -58,6 +59,14 @@ const actionCreators = {
     payload: {
       chainAlias,
       state
+    }
+  }),
+
+  chainNewBlock: (chainAlias, block) => ({
+    type: actionTypes.CHAIN_NEW_BLOCK,
+    payload: {
+      chainAlias,
+      block
     }
   }),
 

--- a/packages/interbit-ui-tools/src/localDataStorage/index.js
+++ b/packages/interbit-ui-tools/src/localDataStorage/index.js
@@ -1,0 +1,14 @@
+const localforage = require('localforage')
+
+const DATASTORE_KEYS = {
+  KEY_PAIR: 'interbit-keypair'
+}
+
+const storageConfig = {
+  name: 'interbit-ui-tools',
+  storeName: 'interbit_ui_tools'
+}
+
+const getDataStore = async () => localforage.createInstance(storageConfig)
+
+module.exports = { getDataStore, DATASTORE_KEYS }

--- a/packages/interbit-ui-tools/src/localDataStorage/index.js
+++ b/packages/interbit-ui-tools/src/localDataStorage/index.js
@@ -9,6 +9,10 @@ const storageConfig = {
   storeName: 'interbit_ui_tools'
 }
 
-const getDataStore = async () => localforage.createInstance(storageConfig)
+const getDataStore = async () => {
+  const datastore = await localforage.createInstance(storageConfig)
+  await datastore.ready()
+  return datastore
+}
 
 module.exports = { getDataStore, DATASTORE_KEYS }

--- a/packages/interbit-ui-tools/src/middleware.js
+++ b/packages/interbit-ui-tools/src/middleware.js
@@ -100,6 +100,11 @@ const subscribeToChain = (store, chainAlias, chain) => {
   chain.subscribe(() => {
     const appState = chain.getState()
     store.dispatch(actionCreators.chainUpdated(chainAlias, appState))
+  })
+
+  chain.blockSubscribe(() => {
+    const currentBlock = chain.getCurrentBlock()
+    store.dispatch(actionCreators.chainNewBlock(chainAlias, currentBlock))
 
     if (firstBlock) {
       store.dispatch(actionCreators.chainBlocking(chainAlias))

--- a/packages/interbit-ui-tools/src/reducer.js
+++ b/packages/interbit-ui-tools/src/reducer.js
@@ -20,7 +20,7 @@ const reducer = (state = initialState, action = {}) => {
   if (
     action.type &&
     action.type.startsWith(ACTION_PREFIX) &&
-    action.type !== actionTypes.CHAIN_UPDATED
+    action.type !== actionTypes.CHAIN_NEW_BLOCK
   ) {
     console.log(`${LOG_PREFIX}: reducer()`, action)
   }

--- a/packages/interbit-ui-tools/src/sagas/chains.js
+++ b/packages/interbit-ui-tools/src/sagas/chains.js
@@ -26,7 +26,11 @@ function* loadPrivateChain({
     })
 
     const privateChainKey = getPrivateChainKey(publicChainId, chainAlias)
-    const savedChainId = yield call(localDataStore.getItem, privateChainKey)
+    const savedChainId = yield call(
+      getChainIdFromLocalDataStore,
+      localDataStore,
+      privateChainKey
+    )
 
     if (
       shouldLoadPrivateChainFromOtherDevice({
@@ -42,7 +46,12 @@ function* loadPrivateChain({
       })
 
       if (privateChain) {
-        yield call(localDataStore.setItem, privateChainKey, privateChainId)
+        yield call(
+          saveChainIdToLocalDataStore,
+          localDataStore,
+          privateChainKey,
+          privateChainId
+        )
         chainId = privateChainId
       }
     }
@@ -78,7 +87,12 @@ function* loadPrivateChain({
         chainId: newChainId
       })
 
-      yield call(localDataStore.setItem, privateChainKey, newChainId)
+      yield call(
+        saveChainIdToLocalDataStore,
+        localDataStore,
+        privateChainKey,
+        newChainId
+      )
       chainId = newChainId
     }
 
@@ -114,6 +128,17 @@ const shouldLoadPrivateChainFromLocalDataStore = ({ savedChainId }) =>
 
 const getPrivateChainKey = (parentChainId, chainAlias) =>
   `chainId-${chainAlias}-${parentChainId}`
+
+const getChainIdFromLocalDataStore = async (localDataStore, chainKey) =>
+  localDataStore.getItem(chainKey)
+
+const saveChainIdToLocalDataStore = async (
+  localDataStore,
+  chainKey,
+  chainId
+) => {
+  localDataStore.setItem(chainKey, chainId)
+}
 
 function* sponsorChain({
   interbit,

--- a/packages/interbit-ui-tools/src/sagas/index.js
+++ b/packages/interbit-ui-tools/src/sagas/index.js
@@ -58,11 +58,14 @@ function* privateChainSaga(action) {
     action.payload || {}
 
   try {
-    const { interbit, cli, publicKey } = yield call(interbitContext)
+    const { interbit, cli, localDataStore, publicKey } = yield call(
+      interbitContext
+    )
 
     yield call(loadPrivateChain, {
       interbit,
       cli,
+      localDataStore,
       publicKey,
       publicChainAlias,
       chainAlias: privateChainAlias,

--- a/packages/interbit/package.json
+++ b/packages/interbit/package.json
@@ -12,7 +12,7 @@
     "cheerio": "^1.0.0-rc.2",
     "deep-diff": "^1.0.1",
     "fs-extra": "^5.0.0",
-    "interbit-core": "0.13.0",
+    "interbit-core": "0.14.0",
     "interbit-covenant-tools": "0.4.31",
     "json-stable-stringify": "^1.0.1",
     "lodash": "^4.17.5",


### PR DESCRIPTION
This updates the version number for `interbit-core` and `interbit-covenant-utils` and gets the middleware going again. State updates and new blocks generate different actions (`CHAIN_UPDATED` and `CHAIN_NEW_BLOCK` respectively).

The default UI reducer doesn't listen to the `CHAIN_NEW_BLOCK` action so the UI no longer re-renders with every block.

The block explorer will be updated in a separate PR to keep the PRs small.