### PR TITLE
Add watch as a dependency of interbit

### DIFF
--- a/packages/interbit/package.json
+++ b/packages/interbit/package.json
@@ -17,7 +17,8 @@
     "json-stable-stringify": "^1.0.1",
     "lodash": "^4.17.5",
     "object-hash": "^1.3.0",
-    "path": "^0.12.7"
+    "path": "^0.12.7",
+    "watch": "^1.0.2"
   },
   "devDependencies": {
     "assert": "^1.4.1",


### PR DESCRIPTION
Should fix the error where interbit-cli (which includes interbit which uses watch) keys command can't find watch dependency.

Closes #566 