### PR TITLE
Revert "Preserve browser hypervisor chain id"

### DIFF
--- a/packages/interbit-ui-tools/src/middleware/interbitGlobal.js
+++ b/packages/interbit-ui-tools/src/middleware/interbitGlobal.js
@@ -27,25 +27,7 @@ const createContext = async () => {
   }
 
   console.log(`${LOG_PREFIX}: Starting interbit hypervisor`)
-  const hypervisorChainId = await localDataStore.getItem(
-    DATASTORE_KEYS.HYPERVISOR_CHAIN_ID
-  )
-  const hypervisor = await interbit.createHypervisor({
-    keyPair,
-    existingId: hypervisorChainId
-  })
-
-  console.log(`${LOG_PREFIX}: Hypervisor running:`, {
-    version: interbit.VERSION,
-    chainId: hypervisor.chainId
-  })
-
-  if (!hypervisorChainId) {
-    await localDataStore.setItem(
-      DATASTORE_KEYS.HYPERVISOR_CHAIN_ID,
-      hypervisor.chainId
-    )
-  }
+  const hypervisor = await interbit.createHypervisor({ keyPair })
 
   console.log(`${LOG_PREFIX}: Creating interbit client`)
   const cli = await interbit.createCli(hypervisor)

--- a/packages/interbit-ui-tools/src/middleware/localDataStorage.js
+++ b/packages/interbit-ui-tools/src/middleware/localDataStorage.js
@@ -1,8 +1,7 @@
 const localforage = require('localforage')
 
 const DATASTORE_KEYS = {
-  KEY_PAIR: 'interbit-keypair',
-  HYPERVISOR_CHAIN_ID: 'hypervisor-chain-id'
+  KEY_PAIR: 'interbit-keypair'
 }
 
 const storageConfig = {


### PR DESCRIPTION
Reusing the browser hypervisor key prevents running interbit in multiple browser tabs, breaking cAuth.

This reverts commit 99d9e8ca4a754930d3504754dee9362592c04f56.

Closes #577 