### PR TITLE
Don't run build:modules during heroku-postbuild - it runs in postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "cross-env-shell lerna run --scope $APP_NAME build",
     "build:modules": "lerna run --scope interbit-* build",
     "postinstall": "lerna bootstrap --hoist --parallel && npm run build:modules",
-    "heroku-postbuild": "npm run build:modules && npm run build",
+    "heroku-postbuild": "npm run build",
     "start": "cross-env-shell lerna run --scope $APP_NAME serve --stream",
     "test": "npm run lint && lerna run --parallel test -- -- --coverage",
     "lint": "eslint .",

--- a/packages/utils/src/standards/std.package.json
+++ b/packages/utils/src/standards/std.package.json
@@ -10,7 +10,7 @@
     "build": "cross-env-shell lerna run --scope $APP_NAME build",
     "build:modules": "lerna run --scope interbit-* build",
     "postinstall": "lerna bootstrap --hoist --parallel && npm run build:modules",
-    "heroku-postbuild": "npm run build:modules && npm run build",
+    "heroku-postbuild": "npm run build",
     "start": "cross-env-shell lerna run --scope $APP_NAME serve --stream",
     "test": "npm run lint && lerna run --parallel test -- -- --coverage",
     "lint": "eslint .",


### PR DESCRIPTION
Closes #581 

Don't run build:modules during heroku-postbuild - it runs in postinstall