### PR TITLE
Covenant aliases correctly mapped to hashes in the manifest

### DIFF
--- a/packages/interbit/src/manifest/createManifestTree.js
+++ b/packages/interbit/src/manifest/createManifestTree.js
@@ -26,9 +26,7 @@ const createManifestTree = (interbitConfig, manifest) => {
   const validators = getAdminValidators(config)
   const chains = getRootSubtrees(ROOT_CHAIN_ALIAS, config, manifest)
   const covenant = ROOT_CHAIN_ALIAS
-  console.log('COVVENANTES')
-  console.log(manifest.covenants)
-  const covenantHashMap = getSubtreeCovenants(
+  const covenantHashMap = getCovenantHashMap(
     ROOT_CHAIN_ALIAS,
     manifest.covenants,
     chains
@@ -112,7 +110,7 @@ const getManifestEntry = (chainAlias, config, manifest, visited) => {
   )
 
   const covenant = getChainCovenant(chainAlias, config)
-  const covenantHashMap = getSubtreeCovenants(
+  const covenantHashMap = getCovenantHashMap(
     covenant,
     manifest.covenants,
     childChains
@@ -186,10 +184,11 @@ const checkForCycles = (chainAlias, visited) => {
   return visited.concat(chainAlias)
 }
 
-const getSubtreeCovenants = (myCovenantAlias, allCovenants, chains) => ({
+const getCovenantHashMap = (myCovenantAlias, allCovenants, chains) => ({
   [myCovenantAlias]: allCovenants[myCovenantAlias].hash,
   ...Object.values(chains).reduce(
     (accum, chain) => ({
+      ...accum,
       ...chain.covenantHashMap
     }),
     {}

--- a/packages/interbit/src/manifest/createManifestTree.js
+++ b/packages/interbit/src/manifest/createManifestTree.js
@@ -26,9 +26,11 @@ const createManifestTree = (interbitConfig, manifest) => {
   const validators = getAdminValidators(config)
   const chains = getRootSubtrees(ROOT_CHAIN_ALIAS, config, manifest)
   const covenant = ROOT_CHAIN_ALIAS
+  console.log('COVVENANTES')
+  console.log(manifest.covenants)
   const covenantHashMap = getSubtreeCovenants(
     ROOT_CHAIN_ALIAS,
-    covenant,
+    manifest.covenants,
     chains
   )
 
@@ -110,7 +112,11 @@ const getManifestEntry = (chainAlias, config, manifest, visited) => {
   )
 
   const covenant = getChainCovenant(chainAlias, config)
-  const covenantHashMap = getSubtreeCovenants(chainAlias, covenant, childChains)
+  const covenantHashMap = getSubtreeCovenants(
+    covenant,
+    manifest.covenants,
+    childChains
+  )
 
   const existingJoins = getChainJoins(chainAlias, config)
   const joins = configureCascadingJoins(
@@ -180,11 +186,11 @@ const checkForCycles = (chainAlias, visited) => {
   return visited.concat(chainAlias)
 }
 
-const getSubtreeCovenants = (chainAlias, myCovenant, chains) => ({
-  [chainAlias]: myCovenant,
+const getSubtreeCovenants = (myCovenantAlias, allCovenants, chains) => ({
+  [myCovenantAlias]: allCovenants[myCovenantAlias].hash,
   ...Object.values(chains).reduce(
     (accum, chain) => ({
-      ...chain.covenants
+      ...chain.covenantHashMap
     }),
     {}
   )

--- a/packages/interbit/src/tests/manifest/generateManifest.test.js
+++ b/packages/interbit/src/tests/manifest/generateManifest.test.js
@@ -207,7 +207,7 @@ describe('generateManifest(location, interbitConfig, covenants, originalManifest
     should.ok(manifest.manifest[ROOT_CHAIN_ALIAS].chains.public)
   })
 
-  it.only('includes necessary configuration data in manifest tree', () => {
+  it('includes necessary configuration data in manifest tree', () => {
     const manifest = generateManifest(location, defaultConfig, defaultCovenants)
 
     should.ok(manifest.manifest)
@@ -223,6 +223,18 @@ describe('generateManifest(location, interbitConfig, covenants, originalManifest
     should.ok(rootChain.validators)
     should.ok(rootChain.covenant)
     should.ok(rootChain.covenantHashMap)
+    should.equal(
+      rootChain.covenantHashMap.interbitRoot,
+      manifest.covenants.interbitRoot.hash
+    )
+    should.equal(
+      rootChain.covenantHashMap.control,
+      manifest.covenants.control.hash
+    )
+    should.equal(
+      rootChain.covenantHashMap.public,
+      manifest.covenants.public.hash
+    )
     should.ok(rootChain.joins)
     should.ok(rootChain.chains)
     // should.ok(rootChain.acl)
@@ -237,9 +249,8 @@ describe('generateManifest(location, interbitConfig, covenants, originalManifest
     should.ok(controlChain.validators)
     should.ok(controlChain.covenant)
     should.ok(controlChain.covenantHashMap)
-    console.log(controlChain.covenantHashMap)
     should.equal(
-      controlChain.covenantHashMap.interbitRoot,
+      controlChain.covenantHashMap.control,
       manifest.covenants.control.hash
     )
     should.ok(controlChain.joins)

--- a/packages/interbit/src/tests/manifest/generateManifest.test.js
+++ b/packages/interbit/src/tests/manifest/generateManifest.test.js
@@ -207,7 +207,7 @@ describe('generateManifest(location, interbitConfig, covenants, originalManifest
     should.ok(manifest.manifest[ROOT_CHAIN_ALIAS].chains.public)
   })
 
-  it('includes necessary configuration data in manifest tree', () => {
+  it.only('includes necessary configuration data in manifest tree', () => {
     const manifest = generateManifest(location, defaultConfig, defaultCovenants)
 
     should.ok(manifest.manifest)
@@ -237,6 +237,11 @@ describe('generateManifest(location, interbitConfig, covenants, originalManifest
     should.ok(controlChain.validators)
     should.ok(controlChain.covenant)
     should.ok(controlChain.covenantHashMap)
+    console.log(controlChain.covenantHashMap)
+    should.equal(
+      controlChain.covenantHashMap.interbitRoot,
+      manifest.covenants.control.hash
+    )
     should.ok(controlChain.joins)
     should.ok(controlChain.chains)
     // should.ok(controlChain.acl)

--- a/packages/interbit/src/tests/testData/index.js
+++ b/packages/interbit/src/tests/testData/index.js
@@ -79,6 +79,11 @@ const defaultManifest = {
       filename:
         'covenants/72fe3ca61c3af35ecca31e58c33c368e1554dc1dab01ab8fc3aadc965f608775.tgz',
       hash: '72fe3ca61c3af35ecca31e58c33c368e1554dc1dab01ab8fc3aadc965f608775'
+    },
+    interbitRoot: {
+      filename:
+        'covenants/4fd5sca61c3af35ecca31e58c33c368e1554dc1dab01ab8fc3aadc965f608775.tgz',
+      hash: '4fd5sca61c3af35ecca31e58c33c368e1554dc1dab01ab8fc3aadc965f608775'
     }
   },
   chains: {
@@ -220,13 +225,24 @@ const defaultManifest = {
   },
   manifest: {
     interbitRoot: {
+      alias: 'interbitRoot',
       chainId:
         '56399770d33b17fe3ba20a1d911cc56c3cc47ed11fc8f6935543c2b25da96f47',
+      chainIdMap: {
+        control:
+          '7988dc0fe96bf5371909781b9cab0de21fcca8a740573267b1134e6889922162',
+        public:
+          '28884c86bb5f73e48726ebdc466d45f4034a22c7ce9b69e5b75bd94d55f78d7f'
+      },
       validators: ['SuperSecurePubKey'],
       covenant: 'interbitRoot',
-      covenants: {
-        interbitRoot: 'interbitRoot',
-        control: 'control'
+      covenantHashMap: {
+        interbitRoot:
+          '4fd5sca61c3af35ecca31e58c33c368e1554dc1dab01ab8fc3aadc965f608775',
+        control:
+          '1abaa91370f606b575ba2bca4dc13a3717aba7c6b09b95b23334c89eb98650fa',
+        public:
+          '72fe3ca61c3af35ecca31e58c33c368e1554dc1dab01ab8fc3aadc965f608775'
       },
       joins: {
         sendActionTo: [
@@ -241,12 +257,20 @@ const defaultManifest = {
       },
       chains: {
         public: {
+          alias: 'public',
           chainId:
             '28884c86bb5f73e48726ebdc466d45f4034a22c7ce9b69e5b75bd94d55f78d7f',
+          chainIdMap: {
+            control:
+              '7988dc0fe96bf5371909781b9cab0de21fcca8a740573267b1134e6889922162',
+            interbitRoot:
+              '56399770d33b17fe3ba20a1d911cc56c3cc47ed11fc8f6935543c2b25da96f47'
+          },
           validators: ['SuperSecurePubKey'],
           covenant: 'public',
-          covenants: {
-            public: 'public'
+          covenantHashMap: {
+            public:
+              '72fe3ca61c3af35ecca31e58c33c368e1554dc1dab01ab8fc3aadc965f608775'
           },
           joins: {
             consume: [
@@ -265,15 +289,23 @@ const defaultManifest = {
             ]
           },
           chains: {},
-          hash: '89bcadf6c8eb1aa9923cd226d84795faede41a13'
+          hash: '4534531a7e3fb794d178e87fd12ce41853f85e4a'
         },
         control: {
+          alias: 'control',
           chainId:
             '7988dc0fe96bf5371909781b9cab0de21fcca8a740573267b1134e6889922162',
+          chainIdMap: {
+            public:
+              '28884c86bb5f73e48726ebdc466d45f4034a22c7ce9b69e5b75bd94d55f78d7f',
+            interbitRoot:
+              '56399770d33b17fe3ba20a1d911cc56c3cc47ed11fc8f6935543c2b25da96f47'
+          },
           validators: ['SuperSecurePubKey'],
           covenant: 'control',
-          covenants: {
-            control: 'control'
+          covenantHashMap: {
+            control:
+              '1abaa91370f606b575ba2bca4dc13a3717aba7c6b09b95b23334c89eb98650fa'
           },
           joins: {
             provide: [
@@ -292,13 +324,13 @@ const defaultManifest = {
             ]
           },
           chains: {},
-          hash: '49cb6f7ffaf3a8d36df768b396f06b7801774c95'
+          hash: 'd058115c23797f2f8167286f3ce1cc6510eedcc4'
         }
       },
-      hash: '11e3653946edd5ff9c0b0d66f8e1b92739ae2a20'
+      hash: '6579b116d3f76666bca7ead9a53afbca849b467f'
     }
   },
-  hash: '1198fac62f12081651cb00b88081117a3085f593'
+  hash: 'fd008fd0d71a1f78e1f626849c170c3d0e588115'
 }
 
 const defaultCovenants = defaultManifest.covenants


### PR DESCRIPTION
Fix bug where covenantHashMap included only covenant aliases. Closes #609 

- added manifest context to test data from issue #596 
- Included covenant hashes mapped by alias for all concerned chains in manifest entries