### PR TITLE
Remove blocks from interbit-covenant-tools

### DIFF
--- a/packages/interbit-covenant-tools/src/coreCovenant/constants.js
+++ b/packages/interbit-covenant-tools/src/coreCovenant/constants.js
@@ -10,7 +10,6 @@ const PATHS = {
   ACL: [INTERBIT, CONFIG, ACL],
   ACTION_PERMISSIONS: [INTERBIT, CONFIG, ACL, 'actionPermissions'],
   ROLES: [INTERBIT, CONFIG, ACL, 'roles'],
-  BLOCKS: [INTERBIT, 'blocks'],
   SENT_ACTIONS: [INTERBIT, 'sent-actions'],
   PENDING_ACTIONS: ['pending-actions']
 }

--- a/packages/interbit-covenant-tools/src/coreCovenant/selectors.js
+++ b/packages/interbit-covenant-tools/src/coreCovenant/selectors.js
@@ -5,7 +5,6 @@ module.exports = {
   actionPermissions: state => state.getIn(PATHS.ACTION_PERMISSIONS),
   chainId: state => state.getIn(PATHS.CHAIN_ID),
   config: state => state.getIn(PATHS.CONFIG),
-  blocks: state => state.getIn(PATHS.BLOCKS),
   sentActions: state => state.getIn(PATHS.SENT_ACTIONS),
   pendingActionsForChain: (state, chainId) =>
     state.getIn([...PATHS.SENT_ACTIONS, chainId, ...PATHS.PENDING_ACTIONS]),

--- a/packages/interbit-covenant-tools/src/tests/exports.test.js
+++ b/packages/interbit-covenant-tools/src/tests/exports.test.js
@@ -30,7 +30,6 @@ describe('module exports expected API', () => {
     assert.ok(api.coreCovenant.pushUpRedispatches)
     assert.ok(api.coreCovenant.selectors)
     assert.ok(api.coreCovenant.selectors.chainId)
-    assert.ok(api.coreCovenant.selectors.blocks)
     assert.ok(api.coreCovenant.selectors.config)
   })
 


### PR DESCRIPTION
These constants and selectors were not used anywhere. Just as well since blocks are no longer part of state.

Closes #642 