### PR TITLE
Make ActionForm go again

### DIFF
--- a/packages/interbit-ui-components/src/components/Covenant/ActionForm/index.js
+++ b/packages/interbit-ui-components/src/components/Covenant/ActionForm/index.js
@@ -1,24 +1,24 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { SubmissionError } from 'redux-form'
-// import EditableTable from '../../FormTable/EditableTable'
-// import { buildDefinition } from './definition'
+import EditableTable from '../../FormTable/EditableTable'
+import { buildDefinition } from './definition'
 
 export default class ActionForm extends Component {
   static propTypes = {
-    // payloadFields: PropTypes.arrayOf(PropTypes.string).isRequired,
+    payloadFields: PropTypes.arrayOf(PropTypes.string).isRequired,
     type: PropTypes.string.isRequired,
-    // isConnected: PropTypes.bool,
-    // isCreating: PropTypes.bool,
+    isConnected: PropTypes.bool,
+    isCreating: PropTypes.bool,
     reset: PropTypes.func.isRequired,
     actionCreator: PropTypes.func.isRequired,
     blockchainDispatch: PropTypes.func.isRequired
   }
 
-  // static defaultProps = {
-  // isCreating: false,
-  // isConnected: true
-  // }
+  static defaultProps = {
+    isCreating: false,
+    isConnected: true
+  }
 
   handleSubmit = formValues => {
     try {
@@ -37,13 +37,12 @@ export default class ActionForm extends Component {
   }
 
   render() {
-    // const { type, payloadFields, isConnected, isCreating } = this.props
-    const { type } = this.props
+    const { type, payloadFields, isConnected, isCreating } = this.props
 
     return (
       <div>
         <h4>{type}</h4>
-        {/* <EditableTable
+        <EditableTable
           form={type}
           styles={{}}
           onSubmit={this.handleSubmit}
@@ -52,7 +51,7 @@ export default class ActionForm extends Component {
           bodyWidth={8}
           submitLabel="Dispatch Action"
           definition={buildDefinition(payloadFields, isConnected)}
-        /> */}
+        />
       </div>
     )
   }

--- a/packages/interbit-ui-components/src/components/FormTable/EditableTable.js
+++ b/packages/interbit-ui-components/src/components/FormTable/EditableTable.js
@@ -9,7 +9,6 @@ import {
   Field
 } from 'redux-form'
 import { renderInput } from '../../help/reduxForm/reduxForm'
-import { createFieldValidator } from '../../help/reduxForm/validation'
 
 class EditableTable extends Component {
   static propTypes = {
@@ -89,7 +88,7 @@ class EditableTable extends Component {
                         component={renderInput}
                         label={o.label}
                         disabled={o.readOnly}
-                        validate={createFieldValidator(o.validators)}
+                        validate={o.validators}
                         selectPlaceholder={o.selectPlaceholder}
                         selectValues={o.selectValues}
                         labelSm={4}


### PR DESCRIPTION
Resolves the following error:
```
Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops
```