### PR TITLE
interbit:start does not issue SET_MANIFEST actions to control chain

### DIFF
--- a/packages/interbit/src/chainManagement/generateDeploymentDetails.js
+++ b/packages/interbit/src/chainManagement/generateDeploymentDetails.js
@@ -9,8 +9,8 @@ const log = require('../log')
  * @param {Object} covenants - The map of covenant aliases to covenant hashes.
  * @returns {Object} - Details of node deployment.
  */
-const generateDeploymentDetails = (chainManifest, covenants) => {
-  log.info({ chainManifest, covenants })
+const generateDeploymentDetails = (chainManifest, covenantHashes) => {
+  log.info({ chainManifest, covenantHashes })
   return {
     chains: Object.entries(chainManifest).reduce(
       (chains, [alias, chainData]) => ({
@@ -19,7 +19,13 @@ const generateDeploymentDetails = (chainManifest, covenants) => {
       }),
       {}
     ),
-    covenants
+    covenants: Object.entries(covenantHashes).reduce(
+      (covenants, [alias, hash]) => ({
+        ...covenants,
+        [alias]: { hash }
+      }),
+      {}
+    )
   }
 }
 

--- a/packages/interbit/src/chainManagement/index.js
+++ b/packages/interbit/src/chainManagement/index.js
@@ -4,6 +4,7 @@ const generateDeploymentDetails = require('./generateDeploymentDetails')
 const startInterbit = require('./startInterbit')
 const setRootChainManifest = require('./setRootChainManifest')
 const watchChain = require('./watchChain')
+const deployCovenants = require('./deployCovenants')
 
 module.exports = {
   configureChains,
@@ -11,5 +12,6 @@ module.exports = {
   generateDeploymentDetails,
   startInterbit,
   setRootChainManifest,
-  watchChain
+  watchChain,
+  deployCovenants
 }

--- a/packages/interbit/src/scripts/start.js
+++ b/packages/interbit/src/scripts/start.js
@@ -41,6 +41,8 @@ const start = async options => {
 
   log.info('available chains + covenants: ', deploymentDetails)
 
+  // required to trigger SET_MANIFEST action on chains for setting-up PPC config
+  // TODO: switch to using a real manifest
   setRootChainManifest(cli, deploymentDetails, config)
 
   if (dev && !noWatch) {

--- a/packages/interbit/src/tests/chainManagement/generateDeploymentDetails.test.js
+++ b/packages/interbit/src/tests/chainManagement/generateDeploymentDetails.test.js
@@ -20,6 +20,6 @@ describe('generateProdConfig(chainManifest, covenantHashes)', () => {
     const prodConfig = generateProdConfig(chainManifest, covenantHashes)
 
     assert.equal(prodConfig.chains.template, chainManifest.template.chainId)
-    assert.equal(prodConfig.covenants.template, covenantHashes.template)
+    assert.equal(prodConfig.covenants.template.hash, covenantHashes.template)
   })
 })


### PR DESCRIPTION
This means the PPC pattern does not work when apps are launched with `npm run interbit:start`