### PR TITLE
Add Blockmaster selector

### DIFF
--- a/packages/interbit-covenant-tools/src/coreCovenant/constants.js
+++ b/packages/interbit-covenant-tools/src/coreCovenant/constants.js
@@ -5,6 +5,7 @@ const ACL = 'acl'
 const PATHS = {
   CHAIN_ID: [INTERBIT, 'chainId'],
   CONFIG: [INTERBIT, CONFIG],
+  BLOCK_MASTER: [INTERBIT, CONFIG, 'blockMaster'],
   CONSUMING: [INTERBIT, CONFIG, 'consuming'],
   PROVIDING: [INTERBIT, CONFIG, 'providing'],
   ACL: [INTERBIT, CONFIG, ACL],

--- a/packages/interbit-covenant-tools/src/coreCovenant/selectors.js
+++ b/packages/interbit-covenant-tools/src/coreCovenant/selectors.js
@@ -10,5 +10,6 @@ module.exports = {
     state.getIn([...PATHS.SENT_ACTIONS, chainId, ...PATHS.PENDING_ACTIONS]),
   providing: state => state.getIn(PATHS.PROVIDING),
   consuming: state => state.getIn(PATHS.CONSUMING),
-  roles: state => state.getIn(PATHS.ROLES)
+  roles: state => state.getIn(PATHS.ROLES),
+  blockMaster: state => state.getIn(PATHS.BLOCK_MASTER)
 }

--- a/packages/interbit-covenant-tools/src/tests/exports.test.js
+++ b/packages/interbit-covenant-tools/src/tests/exports.test.js
@@ -31,6 +31,14 @@ describe('module exports expected API', () => {
     assert.ok(api.coreCovenant.selectors)
     assert.ok(api.coreCovenant.selectors.chainId)
     assert.ok(api.coreCovenant.selectors.config)
+    assert.ok(api.coreCovenant.selectors.blockMaster)
+    assert.ok(api.coreCovenant.selectors.acl)
+    assert.ok(api.coreCovenant.selectors.actionPermissions)
+    assert.ok(api.coreCovenant.selectors.roles)
+    assert.ok(api.coreCovenant.selectors.providing)
+    assert.ok(api.coreCovenant.selectors.consuming)
+    assert.ok(api.coreCovenant.selectors.sentActions)
+    assert.ok(api.coreCovenant.selectors.pendingActionsForChain)
   })
 
   it('rootCovenant', () => {


### PR DESCRIPTION
I needed to obtain the `blockMaster` public key for child chain creation in `app-project`.

Also added exports tests for selectors that were already exported but not tested for.