### PR TITLE
Resurrect styleguidist and fix some styles

### DIFF
--- a/packages/interbit-ui-components/src/components/UIKit/LinkBar.md
+++ b/packages/interbit-ui-components/src/components/UIKit/LinkBar.md
@@ -1,17 +1,9 @@
-Bar example:
+Full-sized examples. To see how the component behaves responsively, change your viewport width.
 
 ```js
-const ReactDOM = require('react-dom');
-const { Provider } = require('react-redux');
-const { createStore } = require('redux');
-const { BrowserRouter } = require('react-router-dom');
-const { composeWithDevTools } = require('redux-devtools-extension');
-
-const store = createStore(() => {}, composeWithDevTools());
-
-<Provider store={store}>
-  <BrowserRouter>
-    <LinkBar to="http://google.com" image="placeholder-md.png" title="Interaction Bar" content="Lorem ipsum dolor sit amet." />
-  </BrowserRouter>
-</Provider>
+<div>
+  <LinkBar to="http://google.com" image="placeholder-md.png" title="Default LinkBar" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut rhoncus, velit nec dignissim luctus." />
+  <LinkBar to="http://google.com" className="blue" image="placeholder-md.png" title="Blue LinkBar" content="Apply the 'blue' class to the component. Lorem ipsum dolor sit amet, consectetur adipiscing elit." />
+  <LinkBar to="http://google.com" className="dotted" image="placeholder-md.png" title="Dotted LinkBar" content="Apply the 'dotted' class to the component. Lorem ipsum dolor sit amet, consectetur adipiscing elit." />
+</div>
 ```

--- a/packages/interbit-ui-components/src/scss/interbit/_launchpad.scss
+++ b/packages/interbit-ui-components/src/scss/interbit/_launchpad.scss
@@ -38,6 +38,7 @@
 
   h3 {
     margin-bottom: 8px;
+    color: $ib-white;
   }
 }
 

--- a/packages/interbit-ui-components/src/scss/interbit/_link-bar.scss
+++ b/packages/interbit-ui-components/src/scss/interbit/_link-bar.scss
@@ -16,6 +16,9 @@
   }
 
   .media-body {
+    h3 {
+      color: $ib-blue;
+    }
     p {
       color: $ib-blue;
     }
@@ -55,7 +58,7 @@
     border-color: $ib-blue;
     color: $ib-white;
 
-    p {
+    p, h3 {
       color: $ib-white;
     }
   }

--- a/packages/interbit-ui-components/styleguide.config.js
+++ b/packages/interbit-ui-components/styleguide.config.js
@@ -2,8 +2,8 @@ const path = require('path')
 
 module.exports = {
   components: 'src/components/**/[A-Z]*.js',
-  require: [path.join(__dirname, '/src/css/interbit.css')],
-  assetsDir: 'src/assets',
+  require: [path.join(__dirname, '/dist/css/interbit.css')],
+  assetsDir: path.join(__dirname, '/src/assets'),
   template: 'styleguide/template.html',
   ignore: ['**/src/components/Welcome.js']
 }


### PR DESCRIPTION
`interbit-ui-components` uses `react-styleguidist` to generate a styleguide so that examples of UI components can be viewed easily. 
- fix the styleguide config so that `styleguide:build` runs again
- minor fix to LinkBar and LaunchPad styles as some styles inadvertently changed after merging `interbit-ui-components/src/scss/index.scss` with `interbit-ui-components/src/scss/interbit.scss`