### PR TITLE
(app-interbit-io): programatically remove service worker

### DIFF
--- a/packages/app-account/src/index.js
+++ b/packages/app-account/src/index.js
@@ -14,6 +14,7 @@ import 'interbit-ui-components/dist/css/interbit.css'
 import App from './App'
 
 import { PUBLIC, PRIVATE } from './constants/chainAliases'
+import unregisterServiceWorker from './unregisterServiceWorker'
 import reducers from './redux'
 
 const { browserChainId: sponsoredChainId, privateChainId } = queryString.parse(
@@ -44,3 +45,5 @@ ReactDOM.render(
   </Provider>,
   document.getElementById('root')
 )
+
+unregisterServiceWorker()

--- a/packages/app-account/src/unregisterServiceWorker.js
+++ b/packages/app-account/src/unregisterServiceWorker.js
@@ -1,0 +1,9 @@
+export default function unregister() {
+  if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
+    navigator.serviceWorker.getRegistrations().then(registrations => {
+      for (const registration of registrations) {
+        registration.unregister()
+      }
+    })
+  }
+}

--- a/packages/app-interbit-io/src/index.js
+++ b/packages/app-interbit-io/src/index.js
@@ -26,3 +26,12 @@ ReactDOM.render(
   </Provider>,
   document.getElementById('root')
 )
+
+// Unregister existing service workers in the client. See Issue #725
+if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
+  navigator.serviceWorker.getRegistrations().then(registrations => {
+    for (const registration of registrations) {
+      registration.unregister()
+    }
+  })
+}

--- a/packages/app-interbit-io/src/index.js
+++ b/packages/app-interbit-io/src/index.js
@@ -11,6 +11,7 @@ import 'interbit-ui-components/dist/css/interbit.css'
 import App from './App'
 
 import ScrollToTop from './components/ScrollToTop'
+import unregisterServiceWorker from './unregisterServiceWorker'
 import reducers from './redux'
 
 const store = createStore(reducers, composeWithDevTools())
@@ -27,11 +28,4 @@ ReactDOM.render(
   document.getElementById('root')
 )
 
-// Unregister existing service workers in the client. See Issue #725
-if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
-  navigator.serviceWorker.getRegistrations().then(registrations => {
-    for (const registration of registrations) {
-      registration.unregister()
-    }
-  })
-}
+unregisterServiceWorker()

--- a/packages/app-interbit-io/src/unregisterServiceWorker.js
+++ b/packages/app-interbit-io/src/unregisterServiceWorker.js
@@ -1,0 +1,9 @@
+export default function unregister() {
+  if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
+    navigator.serviceWorker.getRegistrations().then(registrations => {
+      for (const registration of registrations) {
+        registration.unregister()
+      }
+    })
+  }
+}


### PR DESCRIPTION
We removed the service worker registration in a previous PR. This PR removes the service worker from the client. 

See
- https://love2dev.com/blog/how-to-uninstall-a-service-worker/
- https://stackoverflow.com/questions/33704791/how-do-i-uninstall-a-service-worker