### PR TITLE
Upgrade to react-styleguidist v.7.3.11

### DIFF
--- a/packages/interbit-ui-components/package.json
+++ b/packages/interbit-ui-components/package.json
@@ -59,7 +59,7 @@
     "node-sass": "^4.9.3",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-styleguidist": "^6.2.4",
+    "react-styleguidist": "^7.3.11",
     "sass-loader": "^7.1.0",
     "url-loader": "^1.1.1",
     "webpack": "^3.10.0",

--- a/packages/interbit-ui-components/styleguide.config.js
+++ b/packages/interbit-ui-components/styleguide.config.js
@@ -4,7 +4,6 @@ module.exports = {
   components: 'src/components/**/[A-Z]*.js',
   require: [path.join(__dirname, '/dist/css/interbit.css')],
   assetsDir: path.join(__dirname, '/src/assets'),
-  template: 'styleguide/template.html',
   ignore: [
     '**/src/components/Welcome.js',
     '**/src/components/BlockExplorer/**',


### PR DESCRIPTION
The `styleguide:build` command fails after installing `stylelint` to the repo. We upgraded `react-styleguidist` and updated the styleguidist config file to fix this issue. 